### PR TITLE
fix: convert-llama.py supports different max_seq_len.

### DIFF
--- a/converter/convert-llama.py
+++ b/converter/convert-llama.py
@@ -14,10 +14,11 @@ def convert(modelPath, outputPath, targetFloatType):
     with open(paramsPath) as f:
         params = json.load(f)
         if (params['vocab_size'] < 1):
-            raise Exception('Invalid vocab size')
+            raise Exception('vocab_size is invalid, please update params.json file')
+        if (params.get('max_seq_len') is None):
+            raise Exception('max_seq_len is required, please update params.json file')
         params['n_kv_heads'] = params.get('n_kv_heads') or params['n_heads']
         params['head_size'] = params['dim'] / params['n_heads']
-        params['max_seq_len'] = 2048
         params['arch_type'] = 0xABCD00
         params['n_experts'] = 0
         params['n_active_experts'] = 0

--- a/docs/LLAMA.md
+++ b/docs/LLAMA.md
@@ -3,7 +3,9 @@
 ## How to Run Llama 2
 
 1. Download [Llama 2](https://github.com/facebookresearch/llama) weights from Meta. This project supports 7B, 7B-chat, 13B, 13B-chat, 70B and 70B-chat models.
-2. Open the `llama-2-7b/params.json` file and replace `"vocab_size": -1` to `"vocab_size": 32000`.
+2. Open the `llama-2-7b/params.json` file:
+  * replace `"vocab_size": -1` to `"vocab_size": 32000`,
+  * add a new property: `"max_seq_len": 2048`.
 3. Install dependencies of the converter:
 ```sh
 cd converter && pip install -r requirements.txt
@@ -42,24 +44,25 @@ In the table below, you can find the expected size of the converted weights with
     - `Meta-Llama-3-8B/consolidated.00.pth`
     - `Meta-Llama-3-8B/params.json`
     - `Meta-Llama-3-8B/tokenizer.model`
-5. Clone the `https://github.com/b4rtaz/distributed-llama.git` repository.
-6. Install dependencies of the converter:
+5. Open `params.json` and add a new property: `"max_seq_len": 8192`.
+6. Clone the `https://github.com/b4rtaz/distributed-llama.git` repository.
+7. Install dependencies of the converter:
 ```sh
 cd converter && pip install -r requirements.txt
 ```
-7. Convert the model to the Distributed Llama format:
+8. Convert the model to the Distributed Llama format:
 ```bash
 python converter/convert-llama.py path/to/Meta-Llama-3-8B q40
 ```
-8. Convert the tokenizer to the Distributed Llama format:
+9. Convert the tokenizer to the Distributed Llama format:
 ```bash
 python converter/convert-tokenizer-llama3.py path/to/tokenizer.model
 ```
-9. Build the project:
+10. Build the project:
 ```bash
 make main
 ```
-10. Run the Distributed Llama:
+11. Run the Distributed Llama:
 ```bash
 ./main inference --weights-float-type q40 --buffer-float-type q80 --prompt "My name is" --steps 128 --nthreads 8 --model dllama_meta-llama-3-8b_q40.bin --tokenizer llama3-tokenizer.t
 ```


### PR DESCRIPTION
The previous implementation of the llama converter has set always `max_seq_len: 2048`. Llama 3 has a longer context than Llama 2, so now it's required to update `params.json` file manually before the conversion. Unfortunetly Llama repositorium doesn't have this parameter defined in the default configuration.