### PR TITLE
Add additional chat templates to dllama-api

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -31,6 +31,7 @@ AppArgs AppArgs::parse(int argc, char** argv, bool hasMode) {
     args.topp = 0.9f;
     args.steps = 0;
     args.seed = (unsigned long long)time(NULL);
+    args.chat_template = "llama3";
 
     int i = 1;
     if (hasMode && argc > 1) {
@@ -84,6 +85,8 @@ AppArgs AppArgs::parse(int argc, char** argv, bool hasMode) {
             args.topp = atof(argv[i + 1]);
         } else if (strcmp(argv[i], "--seed") == 0) {
             args.seed = atoll(argv[i + 1]);
+        } else if (strcmp(argv[i], "--chat-template") == 0) {
+            args.chat_template = std::string(argv[i + 1]);
         } else {
             printf("Unknown option %s\n", argv[i]);
             exit(EXIT_FAILURE);

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -36,6 +36,9 @@ public:
     // worker
     int port;
 
+    // API specific
+    std::string chat_template;
+
     static AppArgs parse(int argc, char** argv, bool hasMode);
 };
 

--- a/src/apps/dllama-api/dllama-api.cpp
+++ b/src/apps/dllama-api/dllama-api.cpp
@@ -206,6 +206,17 @@ std::string buildChatPrompt(Tokenizer *tokenizer, AppArgs* args, const std::vect
             }
         }
     }
+    else if(chat_template == "openchat3"){
+        auto capitalize = [](const std::string& input) -> std::string {
+            return input.empty() ? input : std::string(1, std::toupper(input[0])) + input.substr(1);
+        };
+        for (int i = 0; i < messages.size(); ++i) {
+            const auto& message = messages[i];
+            oss << "<|start_header_id|>" << "GPT4 Correct " << capitalize(message.role) << "<|end_header_id|>\n\n" << message.content << "<|eot_id|>";
+        }
+
+        oss << "<|start_header_id|>GPT4 Correct Assistant<|end_header_id|>\n\n";
+    }
 
     return oss.str();
 }


### PR DESCRIPTION
I've added a few of the most common chat templates, namely llama2, llama3, chatml and openchat.
This should make a lot more models compatible with distributed-llama's API

Also added an additional argument to AppArgs to let you specify the chat template used by the model on startup instead of on a per request basis.