### PR TITLE
feat: add to tokenizer chat configuration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           make dllama-api
           make funcs-test
           make quants-test
+          make tokenizer-test
           make transformer-test
           make llama2-tasks-test
           make grok1-tasks-test
@@ -37,6 +38,8 @@ jobs:
         run: ./funcs-test
       - name: quants-test
         run: ./quants-test
+      - name: tokenizer-test
+        run: ./tokenizer-test
       - name: transformer-test
         run: ./transformer-test
       - name: llama2-tasks-test
@@ -60,6 +63,7 @@ jobs:
           make dllama-api
           make funcs-test
           make quants-test
+          make tokenizer-test
           make transformer-test
           make llama2-tasks-test
           make grok1-tasks-test
@@ -67,6 +71,8 @@ jobs:
         run: ./funcs-test
       - name: quants-test
         run: ./quants-test
+      - name: tokenizer-test
+        run: ./tokenizer-test
       - name: transformer-test
         run: ./transformer-test
       - name: llama2-tasks-test

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ funcs-test: src/funcs-test.cpp funcs utils quants
 	$(CXX) $(CXXFLAGS) src/funcs-test.cpp -o funcs-test funcs.o utils.o quants.o $(LIBS)
 quants-test: src/quants.cpp utils quants
 	$(CXX) $(CXXFLAGS) src/quants-test.cpp -o quants-test utils.o quants.o $(LIBS)
+tokenizer-test: src/tokenizer-test.cpp tokenizer funcs utils quants
+	$(CXX) $(CXXFLAGS) src/tokenizer-test.cpp -o tokenizer-test tokenizer.o funcs.o utils.o quants.o $(LIBS)
 transformer-test: src/transformer-test.cpp funcs utils quants transformer socket
 	$(CXX) $(CXXFLAGS) src/transformer-test.cpp -o transformer-test funcs.o utils.o quants.o transformer.o socket.o $(LIBS)
 llama2-tasks-test: src/llama2-tasks-test.cpp utils quants funcs socket transformer tasks llama2-tasks tokenizer

--- a/converter/convert-tokenizer-hf.py
+++ b/converter/convert-tokenizer-hf.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
         print()
         print('⭐ To create the tokenizer file you need to manually specify chat template values. Enter \\n for new line.')
         templateChat = {}
-        templateKeys = ['chat_message_start', 'chat_role_start', 'chat_role_end', 'chat_message_end', 'chat_generation_prompt']
+        templateKeys = ['chat_message_start', 'chat_role_start', 'chat_role_end', 'chat_message_end', 'chat_generation_prompt', 'chat_extra_stop']
         for key in templateKeys:
             value = input(f'⏩ Enter value for chat template key "{key}":\n')
             templateChat[key] = value.replace('\\n', '\n')

--- a/converter/convert-tokenizer-hf.py
+++ b/converter/convert-tokenizer-hf.py
@@ -1,0 +1,71 @@
+import sys
+import json
+import os
+writer = __import__('tokenizer-writer')
+
+def openJson(path):
+    with open(path, 'r', encoding='utf-8') as file:
+        return json.load(file)
+
+def printUsage():
+    print('Usage: python convert-tokenizer-hf.py <tokenizerFolderPath> <name>')
+    print()
+    print('Options:')
+    print('  <tokenizerFolderPath> The path to the folder with tokenizer.json and tokenizer_config.json')
+    print('  <name>                The name of the tokenizer (e.g. "llama3")')
+
+if __name__ == '__main__':
+    if (len(sys.argv) < 2):
+        printUsage()
+        exit(1)
+    
+    dirPath = sys.argv[1]
+    name = sys.argv[2]
+    tokenizerConfig = openJson(os.path.join(dirPath, 'tokenizer_config.json'))
+    tokenizer = openJson(os.path.join(dirPath, 'tokenizer.json'))
+
+    assert(tokenizerConfig['tokenizer_class'] == 'PreTrainedTokenizerFast')
+    assert(tokenizer['model']['type'] == 'BPE')
+    i = 0
+    tokens = []
+    scores = []
+    bosId = None
+    eosId = None
+    for token in tokenizer['model']['vocab'].keys():
+        assert(tokenizer['model']['vocab'][token] == i)
+        tokens.append(token.encode('utf8'))
+        scores.append(-float(i))
+        i += 1
+    if ('added_tokens' in tokenizer):
+        for at in tokenizer['added_tokens']:
+            assert(at['id'] == i)
+            tokens.append(at['content'].encode('utf8'))
+            scores.append(-float(i))
+            if (at['content'] == tokenizerConfig['bos_token']):
+                bosId = i
+            if (at['content'] == tokenizerConfig['eos_token']):
+                eosId = i
+            i += 1
+
+    templateChat = None
+    if ('chat_template' in tokenizerConfig):
+        template = tokenizerConfig['chat_template']
+        print('⭐ Found chat template:')
+        print()
+        print(template.replace('\n', '\\n'))
+        print()
+        print('⭐ To create the tokenizer file you need to manually specify chat template values. Enter \\n for new line.')
+        templateChat = {}
+        templateKeys = ['chat_message_start', 'chat_role_start', 'chat_role_end', 'chat_message_end', 'chat_generation_prompt']
+        for key in templateKeys:
+            value = input(f'⏩ Enter value for chat template key "{key}":\n')
+            templateChat[key] = value.replace('\\n', '\n')
+
+    outputFileName = f'dllama_tokenizer_{name}.t'
+    with open(outputFileName, 'wb') as outputFile:
+        writer.writeTokenizer(outputFile, {
+            'bos_id': bosId,
+            'eos_id': eosId,
+            'chat_eos_id': eosId,
+        }, templateChat, tokens, scores)
+    print(f'✅ Created {outputFileName}')

--- a/converter/convert-tokenizer-llama3.py
+++ b/converter/convert-tokenizer-llama3.py
@@ -68,10 +68,7 @@ if __name__ == '__main__':
                 scores.append(score)
                 specialTokenIndex += 1
 
-            maxTokenLength = max(len(t) for t in tokens)
-
             writer.writeTokenizer(outputFile, {
-                'max_token_length': maxTokenLength,
                 'bos_id': bosId,
                 'eos_id': eosId,
                 'chat_eos_id': chatEosId,

--- a/converter/convert-tokenizer-llama3.py
+++ b/converter/convert-tokenizer-llama3.py
@@ -39,9 +39,15 @@ chatTemplate = {
     'chat_extra_stop': ''
 }
 
+def printUsage():
+    print('Usage: python convert-tokenizer-llama3.py <tokenizerPath>')
+    print()
+    print('Options:')
+    print('  <tokenizerPath> The path to the Llama 3 tokenizer model (tokenizer.model)')
+
 if __name__ == '__main__':
     if (len(sys.argv) < 2):
-        print('Invalid usage')
+        printUsage()
         exit(1)
 
     modelPath = sys.argv[1]

--- a/converter/convert-tokenizer-llama3.py
+++ b/converter/convert-tokenizer-llama3.py
@@ -36,6 +36,7 @@ chatTemplate = {
     'chat_role_end': '<|end_header_id|>\n\n',
     'chat_message_end': '<|eot_id|>',
     'chat_generation_prompt': '<|start_header_id|>assistant<|end_header_id|>\n\n',
+    'chat_extra_stop': ''
 }
 
 if __name__ == '__main__':

--- a/converter/tokenizer-writer.py
+++ b/converter/tokenizer-writer.py
@@ -1,0 +1,44 @@
+import struct
+
+def writeTokenizer(file, params, chatTemplate, tokens, scores):
+    headerKeys = {
+        'version': 0,
+        'vocab_size': 1,
+        'max_token_length': 2,
+        'bos_id': 3,
+        'eos_id': 4,
+        'pad_id': 5,
+        'chat_eos_id': 6,
+        'chat_template': 7
+    }
+    header = struct.pack('i', 0x567124)
+
+    nTokens = len(tokens)
+    params['version'] = 0
+    params['vocab_size'] = nTokens
+    if (chatTemplate):
+        params['chat_template'] = len(chatTemplate)
+
+    data = b''
+    for key in params:
+        if key in headerKeys:
+            data += struct.pack('ii', headerKeys[key], params[key])
+        else:
+            print(f'Unknown header key: {key}')
+
+    header += struct.pack('i', len(header) * 2 + len(data))
+    file.write(header)
+    file.write(data)
+    print(params)
+
+    if (chatTemplate):
+        chatTemplateValue = list(chatTemplate.values())
+        nChatTemplates = len(chatTemplateValue)
+        for i in range(0, nChatTemplates):
+            file.write(struct.pack('I', len(chatTemplateValue[i])))
+        for i in range(0, nChatTemplates):
+            file.write(chatTemplateValue[i].encode())
+
+    for i in range(0, nTokens):
+        file.write(struct.pack('fI', scores[i], len(tokens[i])))
+        file.write(tokens[i])

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -113,12 +113,12 @@ void App::run(AppArgs* args, void (*program)(Inference* inference, SocketPool* s
 
     TransformerSpec spec = Transformer::loadSpecFromFile(args->modelPath, nSlices, args->weightsFloatType, args->bufferFloatType);
     TransformerArch arch = TransformerArchFactory::create(&spec);
+    Tokenizer tokenizer(args->tokenizerPath, spec.vocabSize);
 
     if (args->steps == 0 || args->steps > spec.seqLen) {
         args->steps = spec.seqLen;
     }
 
-    Tokenizer tokenizer(args->tokenizerPath, spec.vocabSize);
     Transformer transformer = Transformer::loadRootFromFile(args->modelPath, &spec, socketPool);
     socketPool->setTurbo(true);
 

--- a/src/apps/dllama-api/dllama-api.cpp
+++ b/src/apps/dllama-api/dllama-api.cpp
@@ -316,7 +316,7 @@ public:
                 char* piece = tokenizer->decode(prevToken, token);
                 bool isSafe = isSafePiece(piece);
 
-                int eosType = eosDetector->append(token, isSafe ? piece : "");
+                EosDetectorType eosType = eosDetector->append(token, isSafe ? piece : "");
 
                 if (isSafePiece(piece)) {
                     printf("%s", piece);
@@ -411,14 +411,8 @@ void server(Inference* inference, SocketPool* socketPool, Tokenizer *tokenizer, 
 
     SocketServer* server = new SocketServer(args->port);
 
-    const bool hasExtraStop = tokenizer->chatTemplate[5][0] != '\0';
-    const int nStops = hasExtraStop ? 2 : 1;
-    char* stops[nStops];
-    stops[0] = tokenizer->vocab[tokenizer->chatEosId];
-    if (hasExtraStop)
-        stops[1] = tokenizer->chatTemplate[5];
-
-    EosDetector eosDetector(tokenizer->chatEosId, nStops, (const char**)stops, 1, 1);
+    TokenizerStops stops(tokenizer);
+    EosDetector eosDetector(tokenizer->chatEosId, stops.nStops, stops.stops, stops.maxStopLength, stops.maxStopLength);
     ApiServer api(inference, tokenizer, sampler, args, spec, &eosDetector);
 
     printf("Server URL: http://127.0.0.1:%d/v1/\n", args->port);

--- a/src/apps/dllama/dllama.cpp
+++ b/src/apps/dllama/dllama.cpp
@@ -4,6 +4,9 @@
 #include <cstdio>
 #include <cassert>
 #include <stdexcept>
+#include <sstream>
+#include <string>
+
 #include "../../utils.hpp"
 #include "../../socket.hpp"
 #include "../../transformer.hpp"
@@ -12,20 +15,19 @@
 #include "../../app.hpp"
 
 void generate(Inference* inference, SocketPool* socketPool, Tokenizer *tokenizer, Sampler *sampler, AppArgs* args, TransformerSpec* spec) {
-    assert(args->prompt != NULL);
+    if (args->prompt == NULL)
+        throw std::runtime_error("Prompt is required");
 
     // encode the (string) prompt into tokens sequence
     int numPromptTokens = 0;
-    int* promptTokens = (int*)malloc((strlen(args->prompt) + 3) * sizeof(int)); // +3 for '\0', ?BOS, ?EOS
+    int* promptTokens = new int[strlen(args->prompt) + 3]; // +3 for '\0', ?BOS, ?EOS
 
     // TODO: this is a hack for Grok1. We should have a more general way to handle this
     bool addBos = spec->archType != GROK1;
 
     tokenizer->encode(args->prompt, promptTokens, &numPromptTokens, addBos, false);
-    if (numPromptTokens < 1) {
-        fprintf(stderr, "something is wrong, expected at least 1 prompt token\n");
-        exit(EXIT_FAILURE);
-    }
+    if (numPromptTokens < 1)
+        throw std::runtime_error("Expected at least 1 prompt token");
 
     // start the main loop
     long start = 0;  // used to time our code, only initialized after first iteration
@@ -73,14 +75,14 @@ void generate(Inference* inference, SocketPool* socketPool, Tokenizer *tokenizer
 
         if (args->benchmark)
             printf("🔶 G %4ld ms I %4ld ms T %4ld ms S %6ld kB R %6ld kB ", generationTime, inferenceTime, transferTime, sentBytes / 1024, recvBytes / 1024);
-        safePrintf(piece); // same as printf("%s", piece), but skips "unsafe" bytes
+        safePrintf(piece);
         if (args->benchmark)
             printf("\n");
         fflush(stdout);
         token = next;
     }
 
-    free(promptTokens);
+    delete[] promptTokens;
 
     if (!args->benchmark) printf("\n");
     double avgGenerationTime = totalGenerationTime / (double)pos;
@@ -91,90 +93,118 @@ void generate(Inference* inference, SocketPool* socketPool, Tokenizer *tokenizer
     printf("Avg transfer time:   %.2f ms\n", totalTransferTime / (double)pos);
 }
 
-void chat(Inference* inference, SocketPool* socketPool, Tokenizer* tokenizer, Sampler* sampler, AppArgs* args, TransformerSpec* spec) {
-    char* cliSystemPrompt = NULL;
-    char* cliUserPrompt = NULL;
-    // buffers for reading the system prompt and user prompt from stdin
-    // you'll notice they are soomewhat haphazardly and unsafely set atm
-    char systemPrompt[512];
-    char userPrompt[512];
-    const size_t renderedPromptSize = 1152;
-    char renderedPrompt[renderedPromptSize];
-    int numPromptTokens = 0;
-    int* promptTokens = (int*)malloc(1152 * sizeof(int));
-    int userIdx;
-
-    // start the main loop
-    int8_t userTurn = 1; // user starts
-    int next;        // will store the next token in the sequence
-    int token;       // stores the current token to feed into the transformer
-    int prev_token;
-    pos_t pos = 0;     // position in the sequence
-    while (pos < args->steps) {
-        // when it is the user's turn to contribute tokens to the dialog...
-        if (userTurn) {
-            // get the (optional) system prompt at position 0
-            if (pos == 0) {
-                // at position 0, the user can also contribute a system prompt
-                if (cliSystemPrompt == NULL) {
-                    // system prompt was not passed in, attempt to get it from stdin
-                    readStdin("💻 Enter system prompt (optional): ", systemPrompt, sizeof(systemPrompt));
-                } else {
-                    // system prompt was passed in, use it
-                    strcpy(systemPrompt, cliSystemPrompt);
-                }
-            }
-            // get the user prompt
-            if (pos == 0 && cliUserPrompt != NULL) {
-                // user prompt for position 0 was passed in, use it
-                strcpy(userPrompt, cliUserPrompt);
-            } else {
-                // otherwise get user prompt from stdin
-                readStdin("👱 User: ", userPrompt, sizeof(userPrompt));
-            }
-            // render user/system prompts into the Llama 2 Chat schema
-            if (pos == 0 && systemPrompt[0] != '\0') {
-                char systemTemplate[] = "[INST] <<SYS>>\n%s\n<</SYS>>\n\n%s [/INST]";
-                snprintf(renderedPrompt, renderedPromptSize, systemTemplate, systemPrompt, userPrompt);
-            } else {
-                char userTemplate[] = "[INST] %s [/INST]";
-                snprintf(renderedPrompt, renderedPromptSize, userTemplate, userPrompt);
-            }
-            // encode the rendered prompt into tokens
-            tokenizer->encode(renderedPrompt, promptTokens, &numPromptTokens, true, false);
-            userIdx = 0; // reset the user index
-            userTurn = 0;
-            printf("🤖 Assistant: ");
+size_t readStdin(const char* guide, char* buffer, size_t bufsize) {
+    fflush(stdin);
+    // read a line from stdin, up to but not including \n
+    printf("%s", guide);
+    if (fgets(buffer, bufsize, stdin) != NULL) {
+        size_t len = strlen(buffer);
+        if (len > 0 && buffer[len - 1] == '\n') {
+            buffer[len - 1] = '\0'; // strip newline
+            len--;
         }
-
-        // determine the token to pass into the transformer next
-        if (userIdx < numPromptTokens) {
-            // if we are still processing the input prompt, force the next prompt token
-            token = promptTokens[userIdx++];
-        } else {
-            // otherwise use the next token sampled from previous turn
-            token = next;
-        }
-        // EOS token ends the Assistant turn
-        if (token == tokenizer->eosId) {
-            userTurn = 1;
-        }
-
-        // forward the transformer to get logits for the next token
-        float* logits = inference->infer(token, pos);
-        next = sampler->sample(logits);
-        pos++;
-
-        if (userIdx >= numPromptTokens && next != 2) {
-            // the Assistant is responding, so print its output
-            char* piece = tokenizer->decode(token, next);
-            safePrintf(piece); // same as printf("%s", piece), but skips "unsafe" bytes
-            fflush(stdout);
-        }
-        if (next == tokenizer->eosId) { printf("\n"); }
+        return len;
     }
-    printf("\n");
-    free(promptTokens);
+    return 0;
+}
+
+class Chat {
+private:
+    Inference* inference;
+    Tokenizer* tokenizer;
+    Sampler* sampler;
+    AppArgs* args;
+    TransformerSpec* spec;
+    EosDetector* eosDetector;
+
+public:
+    Chat(Inference* inference, Tokenizer* tokenizer, Sampler* sampler, AppArgs* args, TransformerSpec* spec, EosDetector* eosDetector) {
+        this->inference = inference;
+        this->tokenizer = tokenizer;
+        this->sampler = sampler;
+        this->args = args;
+        this->spec = spec;
+        this->eosDetector = eosDetector;
+    }
+
+    std::string buildMessage(const std::string& role, std::string& message, bool addGenerationPrompt) {
+        std::ostringstream buffer;
+        buffer << tokenizer->chatTemplate[0]; // chatMessageStart
+        buffer << tokenizer->chatTemplate[1]; // chatRoleStart
+        buffer << role;
+        buffer << tokenizer->chatTemplate[2]; // chatRoleEnd
+        buffer << message;
+        buffer << tokenizer->chatTemplate[3]; // chatMessageEnd
+        if (addGenerationPrompt) {
+            buffer << tokenizer->chatTemplate[4]; // chatGenerationPrompt
+        }
+        return buffer.str();
+    }
+
+    void chat() {
+        std::string inputPrompt;
+        char inputBuffer[2048];
+
+        size_t sysPromptLength = readStdin("💻 System prompt (optional): ", inputBuffer, sizeof(inputBuffer));
+        if (sysPromptLength > 0) {
+            std::string sysPrompt = inputBuffer;
+            inputPrompt += buildMessage("system", sysPrompt, false);
+        }
+
+        pos_t pos = 0;
+        int token;
+        do {
+            size_t userPromptLength;
+            do {
+                userPromptLength = readStdin("\n👱 User\n> ", inputBuffer, sizeof(inputBuffer));
+            } while (userPromptLength == 0);
+
+            std::string userPrompt = inputBuffer;
+            inputPrompt += buildMessage("user", userPrompt, true);
+
+            int* inputTokens = new int[inputPrompt.size() + 3];
+            int nInputTokens;
+            tokenizer->encode((char*)inputPrompt.c_str(), inputTokens, &nInputTokens, true, false);
+
+            pos_t userPromptEndPos = (pos_t)std::min(spec->seqLen, pos + nInputTokens - 1);
+            for (pos_t i = 0; pos < userPromptEndPos; pos++, i++) {
+                inference->infer(inputTokens[i], pos);
+                token = inputTokens[i + 1];
+            }
+
+            printf("\n🤖 Assistant\n");
+
+            for (; pos < spec->seqLen; pos++) {
+                int prevToken = token;
+                float* logits = inference->infer(token, pos);
+                token = sampler->sample(logits);
+                char* piece = tokenizer->decode(prevToken, token);
+                bool isSafe = isSafePiece(piece);
+                EosDetectorType eosType = eosDetector->append(token, isSafe ? piece : "");
+                if (eosType == NOT_EOS || eosType == EOS) {
+                    char* delta = eosDetector->getDelta();
+                    if (delta != NULL) {
+                        printf("%s", delta);
+                        fflush(stdout);
+                        eosDetector->clear();
+                    }
+                }
+                if (eosType == EOS) break;
+            }
+
+            inputPrompt.clear();
+        } while (pos < spec->seqLen);
+
+        printf("(end of context)\n");
+    }
+};
+
+void chat(Inference* inference, SocketPool* socketPool, Tokenizer* tokenizer, Sampler* sampler, AppArgs* args, TransformerSpec* spec) {
+    TokenizerStops stops(tokenizer);
+    EosDetector eosDetector(tokenizer->chatEosId, stops.nStops, stops.stops, stops.maxStopLength, stops.maxStopLength);
+
+    Chat chat(inference, tokenizer, sampler, args, spec, &eosDetector);
+    chat.chat();
 }
 
 void worker(AppArgs* args) {

--- a/src/apps/dllama/dllama.cpp
+++ b/src/apps/dllama/dllama.cpp
@@ -186,8 +186,8 @@ public:
                     if (delta != NULL) {
                         printf("%s", delta);
                         fflush(stdout);
-                        eosDetector->clear();
                     }
+                    eosDetector->clear();
                 }
                 if (eosType == EOS) break;
             }

--- a/src/tokenizer-test.cpp
+++ b/src/tokenizer-test.cpp
@@ -1,3 +1,5 @@
+#include <cassert>
+#include <cstring>
 #include "tokenizer.hpp"
 
 #define ASSERT_EOS_TYPE(type, expected) \

--- a/src/tokenizer-test.cpp
+++ b/src/tokenizer-test.cpp
@@ -108,15 +108,6 @@ void testEosDetectorWithLongPadding() {
         assert(strcmp(delta, "lorem") == 0);
     }
 
-    // "hello" + EOS
-    detector.clear();
-    {
-        ASSERT_EOS_TYPE(detector.append(1, "hello"), NOT_EOS);
-        char* delta = detector.getDelta();
-        assert(delta != NULL);
-        assert(strcmp(delta, "lorem") == 0);
-    }
-
     // "lorem|enQ"
     detector.clear();
     {

--- a/src/tokenizer-test.cpp
+++ b/src/tokenizer-test.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cstring>
+#include <cstdlib>
 #include "tokenizer.hpp"
 
 #define ASSERT_EOS_TYPE(type, expected) \

--- a/src/tokenizer-test.cpp
+++ b/src/tokenizer-test.cpp
@@ -1,0 +1,132 @@
+#include "tokenizer.hpp"
+
+#define ASSERT_EOS_TYPE(type, expected) \
+    if (type != expected) { \
+        printf("Expected %d, got %d (line: %d)\n", expected, type, __LINE__); \
+        exit(1); \
+    }
+
+#define EOS_ID 10000
+
+void testEosDetectorWithPadding() {
+    const char* stops[2] = { "<eos>", "<stop>" };
+    EosDetector detector(EOS_ID, 2, stops, 1, 1);
+
+    // "<eos>"
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "<"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "eo"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(3, "s>"), EOS);
+        assert(detector.getDelta() == NULL);
+    }
+
+    // "<stop> "
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "<"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "stop"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(3, "> "), EOS);
+        assert(detector.getDelta() == NULL);
+    }
+
+    // " "
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, " "), NOT_EOS);
+
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, " ") == 0);
+    }
+
+    // "!<eos> "
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "!<"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "eos"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(3, "> "), EOS);
+
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "!") == 0);
+    }
+
+    // "!<eos> "
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "<eo"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "s>XY"), NOT_EOS);
+
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "<eos>XY") == 0);
+    }
+
+    // "<eo" + EOS
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "<eo"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(EOS_ID, "<eos>"), EOS);
+
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "<eo") == 0);
+    }
+
+    // EOS
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(EOS_ID, "<eos>"), EOS);
+        assert(detector.getDelta() == NULL);
+    }
+
+    printf("✅ EosDetector with padding\n");
+}
+
+
+void testEosDetectorWithoutPadding() {
+    const char* stops[1] = { "<eos>" };
+    EosDetector detector(EOS_ID, 1, stops, 0, 0);
+
+    // "<eos>"
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "<"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "eo"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(3, "s>"), EOS);
+        assert(detector.getDelta() == NULL);
+    }
+
+    // " <"
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, " <"), NOT_EOS);
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, " <") == 0);
+    }
+
+    // "<eos> "
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "<eos"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "> "), NOT_EOS);
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "<eos> ") == 0);
+    }
+
+    // EOS
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(EOS_ID, "<eos>"), EOS);
+        assert(detector.getDelta() == NULL);
+    }
+
+    printf("✅ EosDetector without padding\n");
+}
+
+int main() {
+    testEosDetectorWithPadding();
+    testEosDetectorWithoutPadding();
+    return EXIT_SUCCESS;
+}

--- a/src/tokenizer-test.cpp
+++ b/src/tokenizer-test.cpp
@@ -87,6 +87,49 @@ void testEosDetectorWithPadding() {
 }
 
 
+void testEosDetectorWithLongPadding() {
+    const char* stops[1] = { "|end|" };
+    EosDetector detector(EOS_ID, 1, stops, 5, 5);
+
+    // "lipsum"
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "lipsum"), NOT_EOS);
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "lipsum") == 0);
+    }
+
+    // "lorem"
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "lorem"), NOT_EOS);
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "lorem") == 0);
+    }
+
+    // "hello" + EOS
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "hello"), NOT_EOS);
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "lorem") == 0);
+    }
+
+    // "lorem|enQ"
+    detector.clear();
+    {
+        ASSERT_EOS_TYPE(detector.append(1, "lorem|"), MAYBE_EOS);
+        ASSERT_EOS_TYPE(detector.append(2, "enQ"), NOT_EOS);
+        char* delta = detector.getDelta();
+        assert(delta != NULL);
+        assert(strcmp(delta, "lorem|enQ") == 0);
+    }
+
+    printf("✅ EosDetector with long padding\n");
+}
+
 void testEosDetectorWithoutPadding() {
     const char* stops[1] = { "<eos>" };
     EosDetector detector(EOS_ID, 1, stops, 0, 0);
@@ -130,6 +173,7 @@ void testEosDetectorWithoutPadding() {
 
 int main() {
     testEosDetectorWithPadding();
+    testEosDetectorWithLongPadding();
     testEosDetectorWithoutPadding();
     return EXIT_SUCCESS;
 }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -201,7 +201,9 @@ void Tokenizer::encode(char *text, int *tokens, int *nTokens, bool addBos, bool 
     if (text[0] != '\0') {
         char space[] = " ";
         int dummy_prefix = str_lookup(space, sortedVocab, vocabSize);
-        tokens[(*nTokens)++] = dummy_prefix;
+        // TODO: this condition saves us from segmentation fault
+        if (dummy_prefix != -1)
+            tokens[(*nTokens)++] = dummy_prefix;
     }
 
     // Okay UTF-8 time. This will get messy. Here is the reference from Wikipedia:

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -83,6 +83,7 @@ Tokenizer::Tokenizer(char* tokenizerPath, int modelVocabSize) {
                 throw std::runtime_error("Invalid tokenizer header key");
             }
         }
+        assert(version == 0);
 
         if (nChatTemplates > 0) {
             unsigned int templateSizes[nChatTemplates];

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -6,7 +6,6 @@
 
 bool isSafePiece(char *piece);
 void safePrintf(char *piece);
-void readStdin(const char* guide, char* buffer, size_t bufsize);
 
 typedef struct {
     char *str;
@@ -76,6 +75,15 @@ public:
     int sample(float* logits);
     void setTemp(float temp);
     void setSeed(unsigned long long rngSeed);
+};
+
+class TokenizerStops {
+public:
+    const char** stops;
+    size_t nStops;
+    size_t maxStopLength;
+    TokenizerStops(Tokenizer* tokenizer);
+    ~TokenizerStops();
 };
 
 enum EosDetectorType {

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -44,7 +44,7 @@ public:
     char** vocab;
     int bosId;
     int eosId;
-    int chatEosId; // -1 if not used
+    int chatEosId;
     int nChatTemplates;
     char** chatTemplate;
 
@@ -76,6 +76,33 @@ public:
     int sample(float* logits);
     void setTemp(float temp);
     void setSeed(unsigned long long rngSeed);
+};
+
+enum EosDetectorType {
+    MAYBE_EOS = 0,
+    EOS = 1,
+    NOT_EOS = 2,
+};
+
+class EosDetector {
+private:
+    int eosId;
+    size_t nStops;
+    const char** stops;
+    size_t* stopSizes;
+    size_t bufferPos;
+    size_t bufferSize;
+    int eosPos;
+    int paddingLeft;
+    int paddingRight;
+public:
+    char* buffer;
+    EosDetector(int eosId, size_t nStops, const char** stops, int paddingLeft, int paddingRight);
+    ~EosDetector();
+
+    EosDetectorType append(int tokenId, const char* piece);
+    char* getDelta();
+    void clear();
 };
 
 #endif

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -13,8 +13,7 @@ typedef struct {
     int id;
 } TokenIndex;
 
-struct TokenizerHeader {
-    unsigned int magic;
+struct TokenizerOldHeader {
     unsigned int vocabSize;
     unsigned int maxTokenLength;
     int bosId;
@@ -22,18 +21,32 @@ struct TokenizerHeader {
     int padId;
 };
 
+enum TokenizerHeaderKey {
+    TOK_VERSION = 0,
+    TOK_VOCAB_SIZE = 1,
+    MAX_TOKEN_LENGTH = 2,
+    BOS_ID = 3,
+    EOS_ID = 4,
+    PAD_ID = 5,
+    CHAT_EOS_ID = 6,
+    CHAT_TEMPLATE = 7,
+};
+
 class Tokenizer {
 private:
     unsigned int maxTokenLength;
-    char** vocab;
     float* vocabScores;
     TokenIndex *sortedVocab;
     int vocabSize;
     unsigned char bytePieces[512]; // stores all single-byte strings
 
 public:
+    char** vocab;
     int bosId;
     int eosId;
+    int chatEosId; // -1 if not used
+    int nChatTemplates;
+    char** chatTemplate;
 
     Tokenizer(char* tokenizer_path, int vocab_size);
     ~Tokenizer();


### PR DESCRIPTION
This PR extends the tokenizer file format. Now it's possible to add to the tokenzier file the chat configuration.

```
...
 seqLen: 8192
💡 nSlices: 1
💡 ropeTheta: 500000.0
📄 chatTemplate[0]: 
📄 chatTemplate[1]: <|start_header_id|>
📄 chatTemplate[2]: <|end_header_id|>


📄 chatTemplate[3]: <|eot_id|>
📄 chatTemplate[4]: <|start_header_id|>assistant<|end_header_id|>


📄 bosId: 128000
📄 eosId: 128001
📄 chatEosId: 128009
🕒 ropeCache: 131072 kB
⏩ Loaded 6175568 kB
```