### PR TITLE
feat: vulkan.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ server
 /dllama
 /dllama-*
 *.exe
+*.spv

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,15 @@ else
 endif
 
 ifdef DLLAMA_VULKAN
+ifeq ($(OS),Windows_NT)
+LIBS += -L$(VK_SDK_PATH)\lib -lvulkan-1
+OBJS += accelerator-vulkan.o
+CXXFLAGS += -DDLLAMA_VULKAN -I$(VK_SDK_PATH)\include
+else
 LIBS += -lvulkan
 OBJS += accelerator-vulkan.o
 CXXFLAGS += -DDLLAMA_VULKAN
+endif
 
 accelerator-vulkan.o: src/accelerator-vulkan.cpp
 	$(CXX) $(CXXFLAGS) -c src/accelerator-vulkan.cpp -o accelerator-vulkan.o

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,17 @@ else
     LIBS = -lpthread
 endif
 
+ifdef DLLAMA_VULKAN
+LIBS += -lvulkan
+OBJS += accelerator-vulkan.o
+CXXFLAGS += -DDLLAMA_VULKAN
+
+accelerator-vulkan.o: src/accelerator-vulkan.cpp
+	$(CXX) $(CXXFLAGS) -c src/accelerator-vulkan.cpp -o accelerator-vulkan.o
+accelerator-vulkan-test: src/accelerator-vulkan-test.cpp funcs utils quants accelerator-vulkan.o
+	$(CXX) $(CXXFLAGS) src/accelerator-vulkan-test.cpp -o accelerator-vulkan-test funcs.o utils.o quants.o accelerator-vulkan.o $(LIBS)
+endif
+
 utils: src/utils.cpp
 	$(CXX) $(CXXFLAGS) -c src/utils.cpp -o utils.o
 quants: src/quants.cpp
@@ -35,10 +46,10 @@ tokenizer: src/tokenizer.cpp
 app: src/app.cpp
 	$(CXX) $(CXXFLAGS) -c src/app.cpp -o app.o
 
-dllama: src/apps/dllama/dllama.cpp utils quants funcs commands socket transformer tasks llama2-tasks grok1-tasks mixtral-tasks tokenizer app
-	$(CXX) $(CXXFLAGS) src/apps/dllama/dllama.cpp -o dllama utils.o quants.o funcs.o commands.o socket.o transformer.o tasks.o llama2-tasks.o grok1-tasks.o mixtral-tasks.o tokenizer.o app.o $(LIBS)
-dllama-api: src/apps/dllama-api/dllama-api.cpp utils quants funcs commands socket transformer tasks llama2-tasks grok1-tasks mixtral-tasks tokenizer app
-	$(CXX) $(CXXFLAGS) src/apps/dllama-api/dllama-api.cpp -o dllama-api utils.o quants.o funcs.o commands.o socket.o transformer.o tasks.o llama2-tasks.o grok1-tasks.o mixtral-tasks.o tokenizer.o app.o $(LIBS)
+dllama: src/apps/dllama/dllama.cpp utils quants funcs commands socket transformer tasks llama2-tasks grok1-tasks mixtral-tasks tokenizer app ${OBJS}
+	$(CXX) $(CXXFLAGS) src/apps/dllama/dllama.cpp -o dllama utils.o quants.o funcs.o commands.o socket.o transformer.o tasks.o llama2-tasks.o grok1-tasks.o mixtral-tasks.o tokenizer.o app.o ${OBJS} $(LIBS)
+dllama-api: src/apps/dllama-api/dllama-api.cpp utils quants funcs commands socket transformer tasks llama2-tasks grok1-tasks mixtral-tasks tokenizer app ${OBJS}
+	$(CXX) $(CXXFLAGS) src/apps/dllama-api/dllama-api.cpp -o dllama-api utils.o quants.o funcs.o commands.o socket.o transformer.o tasks.o llama2-tasks.o grok1-tasks.o mixtral-tasks.o tokenizer.o app.o ${OBJS} $(LIBS)
 
 funcs-test: src/funcs-test.cpp funcs utils quants
 	$(CXX) $(CXXFLAGS) src/funcs-test.cpp -o funcs-test funcs.o utils.o quants.o $(LIBS)

--- a/src/accelerator-vulkan-test.cpp
+++ b/src/accelerator-vulkan-test.cpp
@@ -42,15 +42,15 @@ int main() {
 
         matmul(F32, F32, outputCpu, input, weights, n, d, 1, 0);
 
-        DEBUG_FLOATS("gpu", outputGpu, 8);
+        DEBUG_FLOATS("matmul f32xf32", outputGpu, 8);
 
         if (compareOutputs(d, outputCpu, outputGpu))
-            printf("✅ gpu matmul f32xf32\n");
+            printf("✅ matmul f32xf32\n");
         else
             success = false;
     }
 
-    for (unsigned n = 512; n <= 4096; n += 512) {
+    for (unsigned n = 512; n <= 704; n += 32) {
         const unsigned d = 128;
         float input[n];
         const unsigned weightsN = (n * d) / QK40;
@@ -74,15 +74,15 @@ int main() {
 
         matmul(Q40, F32, outputCpu, input, weights, n, d, 1, 0);
 
-        DEBUG_FLOATS("gpu", outputGpu, 8);
+        DEBUG_FLOATS("matmul q40xf32", outputGpu, 8);
 
         if (compareOutputs(d, outputCpu, outputGpu))
-            printf("✅ gpu matmul q40xf32 (n=%d)\n", n);
+            printf("✅ matmul q40xf32 (n=%d)\n", n);
         else
             success = false;
     }
 
-    for (unsigned n = 512; n <= 4096; n += 512) {
+    for (unsigned n = 512; n <= 704; n += 32) {
         const unsigned d = 128;
         const unsigned inputN = n / QK80;
         const unsigned weightsN = (n * d) / QK40;
@@ -108,12 +108,12 @@ int main() {
         accelerator.beginForwardMatmul(mmIndex, input);
         accelerator.endForwardMatmul(mmIndex, outputGpu);
 
-        DEBUG_FLOATS("gpu", outputGpu, 8);
+        DEBUG_FLOATS("matmul q40xq80", outputGpu, 8);
 
         matmul(Q40, Q80, outputCpu, input, weights, n, d, 1, 0);
 
         if (compareOutputs(d, outputCpu, outputGpu))
-            printf("✅ gpu matmul q40xq80 (n=%d)\n", n);
+            printf("✅ matmul q40xq80 (n=%d)\n", n);
         else
             success = false;
     }

--- a/src/accelerator-vulkan-test.cpp
+++ b/src/accelerator-vulkan-test.cpp
@@ -1,0 +1,10 @@
+#include "accelerator-vulkan.hpp"
+
+int main() {
+    AcceleratorVulkan accelerator = AcceleratorVulkan();
+
+    unsigned int mmIndex1 = accelerator.allocateMatmul(Q80, Q40, 512, 256);
+    unsigned int mmIndex2 = accelerator.allocateMatmul(Q80, Q40, 512, 256);
+
+    return 0;
+}

--- a/src/accelerator-vulkan-test.cpp
+++ b/src/accelerator-vulkan-test.cpp
@@ -50,7 +50,7 @@ int main() {
             success = false;
     }
 
-    for (unsigned n = 256; n <= 4096; n *= 2) {
+    for (unsigned n = 512; n <= 4096; n += 512) {
         const unsigned d = 128;
         float input[n];
         const unsigned weightsN = (n * d) / QK40;
@@ -82,7 +82,7 @@ int main() {
             success = false;
     }
 
-    for (unsigned n = 256; n <= 4096; n *= 2) {
+    for (unsigned n = 512; n <= 4096; n += 512) {
         const unsigned d = 128;
         const unsigned inputN = n / QK80;
         const unsigned weightsN = (n * d) / QK40;

--- a/src/accelerator-vulkan-test.cpp
+++ b/src/accelerator-vulkan-test.cpp
@@ -15,8 +15,7 @@ bool compareOutputs(unsigned int d, float* cpu, float* gpu) {
 
 int main() {
     initQuants();
-    VulkanContext context = VulkanContext();
-    AcceleratorVulkan accelerator = AcceleratorVulkan(&context);
+    AcceleratorVulkan accelerator = AcceleratorVulkan();
 
     bool success = true;
     unsigned long long state = 1000000L;

--- a/src/accelerator-vulkan-test.cpp
+++ b/src/accelerator-vulkan-test.cpp
@@ -1,10 +1,122 @@
+#include "utils.hpp"
+#include "funcs.hpp"
 #include "accelerator-vulkan.hpp"
 
+bool compareOutputs(unsigned int d, float* cpu, float* gpu) {
+    for (unsigned int i = 0; i < d; i++) {
+        if (fabs(cpu[i] - gpu[i]) > 0.01) {
+            for (unsigned int j = i; j < d; j++)
+                printf("🚨 [%3d] cpu %.9g != gpu %.9g\n", j, cpu[j], gpu[j]);
+            return false;
+        }
+    }
+    return true;
+}
+
 int main() {
-    AcceleratorVulkan accelerator = AcceleratorVulkan();
+    initQuants();
+    VulkanContext context = VulkanContext();
+    AcceleratorVulkan accelerator = AcceleratorVulkan(&context);
 
-    unsigned int mmIndex1 = accelerator.allocateMatmul(Q80, Q40, 512, 256);
-    unsigned int mmIndex2 = accelerator.allocateMatmul(Q80, Q40, 512, 256);
+    bool success = true;
+    unsigned long long state = 1000000L;
+    randomU32(&state);
 
-    return 0;
+    {
+        const unsigned n = 512;
+        const unsigned d = 128;
+        float input[n];
+        float weights[n * d];
+        float outputGpu[d];
+        float outputCpu[d];
+
+        for (unsigned int i = 0; i < n * d; i++) {
+            if (i < n) input[i] = (randomF32(&state) - 0.5f) / 2.0f;
+            weights[i] = (randomF32(&state) - 0.5f) / 2.0f;
+        }
+
+        unsigned int mmIndex = accelerator.allocateMatmul(F32, F32, n, d);
+        accelerator.loadMatmulWeights(mmIndex, weights);
+        accelerator.beginForwardMatmul(mmIndex, input);
+        accelerator.endForwardMatmul(mmIndex, outputGpu);
+
+        matmul(F32, F32, outputCpu, input, weights, n, d, 1, 0);
+
+        DEBUG_FLOATS("gpu", outputGpu, 8);
+
+        if (compareOutputs(d, outputCpu, outputGpu))
+            printf("✅ gpu matmul f32xf32\n");
+        else
+            success = false;
+    }
+
+    for (unsigned n = 256; n <= 4096; n *= 2) {
+        const unsigned d = 128;
+        float input[n];
+        const unsigned weightsN = (n * d) / QK40;
+        BlockQ40 weights[weightsN];
+        float outputGpu[d];
+        float outputCpu[d];
+
+        for (unsigned int i = 0; i < n; i++)
+            input[i] = randomF32(&state) - 0.5f;
+        for (unsigned int i = 0; i < weightsN; i++) {
+            weights[i].d = 40000 + (int)(randomF32(&state) * 1000);
+            for (unsigned int j = 0; j < 16; j++)
+                weights[i].qs[j] = (int8_t)(randomF32(&state) * 256.0);
+        }
+
+        unsigned int mmIndex = accelerator.allocateMatmul(Q40, F32, n, d);
+
+        accelerator.loadMatmulWeights(mmIndex, weights);
+        accelerator.beginForwardMatmul(mmIndex, input);
+        accelerator.endForwardMatmul(mmIndex, outputGpu);
+
+        matmul(Q40, F32, outputCpu, input, weights, n, d, 1, 0);
+
+        DEBUG_FLOATS("gpu", outputGpu, 8);
+
+        if (compareOutputs(d, outputCpu, outputGpu))
+            printf("✅ gpu matmul q40xf32 (n=%d)\n", n);
+        else
+            success = false;
+    }
+
+    for (unsigned n = 256; n <= 4096; n *= 2) {
+        const unsigned d = 128;
+        const unsigned inputN = n / QK80;
+        const unsigned weightsN = (n * d) / QK40;
+        BlockQ80 input[inputN];
+        BlockQ40 weights[weightsN];
+        float outputGpu[d];
+        float outputCpu[d];
+
+        for (unsigned int i = 0; i < inputN; i++) {
+            input[i].d = 38000 + (int)(randomF32(&state) * 1000);
+            for (unsigned int j = 0; j < 32; j++)
+                input[i].qs[j] = (int8_t)(randomF32(&state) * 256.0);
+        }
+        for (unsigned int i = 0; i < weightsN; i++) {
+            weights[i].d = 38000 + (int)(randomF32(&state) * 1000);
+            for (unsigned int j = 0; j < 16; j++)
+                weights[i].qs[j] = (int8_t)(randomF32(&state) * 256.0);
+        }
+
+        unsigned int mmIndex = accelerator.allocateMatmul(Q40, Q80, n, d);
+
+        accelerator.loadMatmulWeights(mmIndex, weights);
+        accelerator.beginForwardMatmul(mmIndex, input);
+        accelerator.endForwardMatmul(mmIndex, outputGpu);
+
+        DEBUG_FLOATS("gpu", outputGpu, 8);
+
+        matmul(Q40, Q80, outputCpu, input, weights, n, d, 1, 0);
+
+        if (compareOutputs(d, outputCpu, outputGpu))
+            printf("✅ gpu matmul q40xq80 (n=%d)\n", n);
+        else
+            success = false;
+    }
+
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/accelerator-vulkan.cpp
+++ b/src/accelerator-vulkan.cpp
@@ -22,6 +22,19 @@ bool hasValidationLayer() {
     return false;
 }
 
+#define MEMORY_TYPE_INDEX_NOT_FOUND ~0
+
+uint32_t findMemoryTypeIndex(VulkanContext* context, vk::MemoryPropertyFlags expectedFlags) {
+    vk::PhysicalDeviceMemoryProperties memoryProperties = context->physicalDevice.getMemoryProperties();
+    for (uint32_t index = 0; index < memoryProperties.memoryTypeCount; ++index) {
+        auto flags = memoryProperties.memoryTypes[index].propertyFlags;
+        if ((flags & expectedFlags) == expectedFlags) {
+            return index;
+        }
+    }
+    return MEMORY_TYPE_INDEX_NOT_FOUND;
+}
+
 void readShaderFile(const char* path, char** output, size_t* fileSize) {
     FILE* fd = fopen(path, "rb");
     if (fd == NULL)
@@ -110,20 +123,8 @@ VulkanContext::~VulkanContext() {
     instance.destroy();
 }
 
-std::pair<vk::Buffer, vk::DeviceMemory> createBuffer(VulkanContext* context, vk::MemoryPropertyFlags memFlagBits, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags) {
+std::pair<vk::Buffer, vk::DeviceMemory> createBuffer(VulkanContext* context, uint32_t memoryTypeIndex, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags) {
 	vk::PhysicalDeviceMemoryProperties memoryProperties = context->physicalDevice.getMemoryProperties();
-
-	uint32_t memoryTypeIndex = uint32_t(~0);
-	for (uint32_t index = 0; index < memoryProperties.memoryTypeCount; ++index) {
-		auto flags = memoryProperties.memoryTypes[index].propertyFlags;
-		if ((flags & memFlagBits) == memFlagBits) {
-			memoryTypeIndex = index;
-			break;
-		}
-	}
-	if (memoryTypeIndex == uint32_t(~0)) {
-		throw std::runtime_error("Cannot find expected memory type");
-	}
 
 	vk::BufferCreateInfo bufferCreateInfo {
 		vk::BufferCreateFlags(), bufferSize, usageFlags,
@@ -140,84 +141,124 @@ std::pair<vk::Buffer, vk::DeviceMemory> createBuffer(VulkanContext* context, vk:
 	return std::make_pair(buffer, bufferMemory);
 }
 
-void copyFromOrToGpu(VulkanContext* context, const uint32_t bufferSize, const bool direction, void* data, vk::Buffer& gpuBuffer) {
-	auto br = createBuffer(context, vk::MemoryPropertyFlagBits::eHostVisible, bufferSize, vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
-	vk::Buffer hostBuffer = br.first;
-	vk::DeviceMemory hostBufferMemory = br.second;
+CopyBufferVulkan::CopyBufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::Buffer& deviceBuffer, CopyBufferVulkanDirection direction) {
+    this->context = context;
+    this->bufferSize = bufferSize;
+    this->deviceBuffer = deviceBuffer;
+    this->direction = direction;
 
-    if (direction) { // direction = 1 => host -> gpu
-        void* localPtr = context->device.mapMemory(hostBufferMemory, 0, bufferSize);
-        memcpy(localPtr, data, bufferSize);
-        context->device.unmapMemory(hostBufferMemory);
-    }
+    uint32_t memoryTypeIndex = findMemoryTypeIndex(context, vk::MemoryPropertyFlagBits::eHostVisible);
+    if (memoryTypeIndex == MEMORY_TYPE_INDEX_NOT_FOUND)
+        throw std::runtime_error("Cannot find host visible memory type");
 
-	vk::CommandBufferAllocateInfo allocInfo(context->commandPool, vk::CommandBufferLevel::ePrimary, 1);
+	auto b = createBuffer(context, memoryTypeIndex, bufferSize, vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+	hostBuffer = b.first;
+	hostMemory = b.second;
+
+    vk::CommandBufferAllocateInfo allocInfo(context->commandPool, vk::CommandBufferLevel::ePrimary, 1);
 	const std::vector<vk::CommandBuffer> cmdBuffers = context->device.allocateCommandBuffers(allocInfo);
-	vk::CommandBuffer cmdBuffer = cmdBuffers.front();
-
-	cmdBuffer.begin({ vk::CommandBufferUsageFlags{} });
+	commandBuffer = cmdBuffers.front();
+	commandBuffer.begin({ vk::CommandBufferUsageFlags{} });
 
 	VkBufferCopy copyRegion = { 0 };
 	copyRegion.size = bufferSize;
-    if (direction) {
-	    vkCmdCopyBuffer(cmdBuffer, hostBuffer, gpuBuffer, 1, &copyRegion);
-    } else {
-        vkCmdCopyBuffer(cmdBuffer, gpuBuffer, hostBuffer, 1, &copyRegion);
+    if (direction == FROM_HOST_TO_DEVICE) {
+	    vkCmdCopyBuffer(commandBuffer, hostBuffer, deviceBuffer, 1, &copyRegion);
+    } else if (direction == FROM_DEVICE_TO_HOST) {
+        vkCmdCopyBuffer(commandBuffer, deviceBuffer, hostBuffer, 1, &copyRegion);
     }
-	cmdBuffer.end();
+	commandBuffer.end();
 
-	vk::SubmitInfo submitInfo(0, nullptr, nullptr, 1, &cmdBuffer);
-	vk::Fence fence = context->device.createFence(vk::FenceCreateInfo());
+    fence = context->device.createFence(vk::FenceCreateInfo());
+}
 
-	//auto t0 = std::chrono::high_resolution_clock::now();
-
-	context->queue.submit({ submitInfo }, fence);
-	auto result = context->device.waitForFences({ fence }, true, uint64_t(-1));
-
-	//auto t1 = std::chrono::high_resolution_clock::now();
-	//auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
-	//printf("copy: %lldms, size: %d kB\n", durationMs, bufferSize / 1024);
-
-    if (!direction) { // direction = 0 => gpu -> host
-        void* localPtr = context->device.mapMemory(hostBufferMemory, 0, bufferSize);
-        memcpy(data, localPtr, bufferSize);
-        context->device.unmapMemory(hostBufferMemory);
-    }
-
+CopyBufferVulkan::~CopyBufferVulkan() {
 	context->device.destroyFence(fence);
-	context->device.freeCommandBuffers(context->commandPool, 1, &cmdBuffer);
+	context->device.freeCommandBuffers(context->commandPool, 1, &commandBuffer);
 
-	context->device.freeMemory(hostBufferMemory);
+	context->device.freeMemory(hostMemory);
 	context->device.destroyBuffer(hostBuffer);
 }
 
-void copyFromGpuMemory(VulkanContext* context, const uint32_t bufferSize, void* target, vk::DeviceMemory& deviceMemory) {
-    void* gpuMemory = static_cast<float*>(context->device.mapMemory(deviceMemory, 0, bufferSize));
-    memcpy(target, gpuMemory, bufferSize);
-    context->device.unmapMemory(deviceMemory);
+void CopyBufferVulkan::copy(void* data) {
+    if (direction == FROM_HOST_TO_DEVICE) {
+        void* local = context->device.mapMemory(hostMemory, 0, bufferSize);
+        memcpy(local, data, bufferSize);
+        context->device.unmapMemory(hostMemory);
+    }
+
+    context->device.resetFences({ fence });
+
+    vk::SubmitInfo submitInfo(0, nullptr, nullptr, 1, &commandBuffer);
+	context->queue.submit({ submitInfo }, fence);
+	auto result = context->device.waitForFences({ fence }, true, uint64_t(-1));
+
+    if (direction == FROM_DEVICE_TO_HOST) {
+        void* local = context->device.mapMemory(hostMemory, 0, bufferSize);
+        memcpy(data, local, bufferSize);
+        context->device.unmapMemory(hostMemory);
+    }
 }
 
-BufferVulkan::BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags) {
+BufferVulkan::BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags, bool fastCopy, CopyBufferVulkanDirection direction) {
     this->context = context;
     this->bufferSize = bufferSize;
 
-    auto b = createBuffer(context, vk::MemoryPropertyFlagBits::eDeviceLocal, bufferSize, 
-        usageFlags | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
-    this->buffer = b.first;
-    this->deviceMemory = b.second;
+    uint32_t memoryTypeIndex = findMemoryTypeIndex(context, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eDeviceLocal);
+    if (memoryTypeIndex != MEMORY_TYPE_INDEX_NOT_FOUND) {
+        isHostVisible = true;
+    } else {
+        isHostVisible = false;
+        memoryTypeIndex = findMemoryTypeIndex(context, vk::MemoryPropertyFlagBits::eDeviceLocal);
+    }
+    if (memoryTypeIndex == MEMORY_TYPE_INDEX_NOT_FOUND)
+        throw std::runtime_error("Cannot find host visible memory type");
+
+    auto b = createBuffer(context, memoryTypeIndex, bufferSize, usageFlags | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+    deviceBuffer = b.first;
+    deviceMemory = b.second;
+
+    if (!isHostVisible && fastCopy)
+        copy = new CopyBufferVulkan(context, bufferSize, deviceBuffer, direction);
+    else
+        copy = NULL;
 }
 
-void BufferVulkan::load(const void* data) {
-    copyFromOrToGpu(context, bufferSize, true, (void*)data, buffer);
+void BufferVulkan::write(const void* data) {
+    if (isHostVisible) {
+        void* local = context->device.mapMemory(deviceMemory, 0, bufferSize);
+        memcpy(local, data, bufferSize);
+        context->device.unmapMemory(deviceMemory);
+    } else if (copy != NULL) {
+        assert(copy->direction == FROM_HOST_TO_DEVICE);
+        copy->copy((void*)data);
+    } else {
+        CopyBufferVulkan cpy = CopyBufferVulkan(context, bufferSize, deviceBuffer, FROM_HOST_TO_DEVICE);
+        cpy.copy((void*)data);
+    }
+}
+
+void BufferVulkan::read(void* data) {
+    if (isHostVisible) {
+        void* local = context->device.mapMemory(deviceMemory, 0, bufferSize);
+        memcpy(data, local, bufferSize);
+        context->device.unmapMemory(deviceMemory);
+    } else if (copy != NULL) {
+        assert(copy->direction == FROM_DEVICE_TO_HOST);
+        copy->copy(data);
+    } else {
+        throw std::runtime_error("Not implemented");
+    }
 }
 
 void BufferVulkan::destroy() {
     this->context->device.freeMemory(deviceMemory);
-    this->context->device.destroyBuffer(buffer);
+    this->context->device.destroyBuffer(deviceBuffer);
+    if (copy != NULL)
+        delete copy;
 }
 
-AcceleratorVulkan::AcceleratorVulkan(VulkanContext* context) {
-    this->context = context;
+AcceleratorVulkan::AcceleratorVulkan() : context(VulkanContext()) {
 }
 
 AcceleratorVulkan::~AcceleratorVulkan() {
@@ -228,13 +269,13 @@ AcceleratorVulkan::~AcceleratorVulkan() {
         mm->outputBuffer.destroy();
         mm->metadataBuffer.destroy();
 
-        context->device.destroyDescriptorSetLayout(mm->descriptorSetLayout);
-		context->device.destroyPipelineLayout(mm->pipelineLayout);
-		context->device.destroyPipelineCache(mm->pipelineCache);
-		context->device.destroyShaderModule(mm->shaderModule);
-		context->device.destroyPipeline(mm->computePipeline);
-		context->device.destroyDescriptorPool(mm->descriptorPool);
-		context->device.destroyFence(mm->fence);
+        context.device.destroyDescriptorSetLayout(mm->descriptorSetLayout);
+		context.device.destroyPipelineLayout(mm->pipelineLayout);
+		context.device.destroyPipelineCache(mm->pipelineCache);
+		context.device.destroyShaderModule(mm->shaderModule);
+		context.device.destroyPipeline(mm->computePipeline);
+		context.device.destroyDescriptorPool(mm->descriptorPool);
+		context.device.destroyFence(mm->fence);
 
         delete mm->shaderData;
     }
@@ -249,10 +290,10 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType,
     const uint32_t metadataBufferSize = sizeof(uint32_t);
 
     MatmulVulkan mm = {
-        .inputBuffer = BufferVulkan(context, inputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer),
-        .weightsBuffer = BufferVulkan(context, weightsBufferSize, vk::BufferUsageFlagBits::eStorageBuffer),
-        .outputBuffer = BufferVulkan(context, outputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer),
-        .metadataBuffer = BufferVulkan(context, metadataBufferSize, vk::BufferUsageFlagBits::eUniformBuffer)
+        .inputBuffer = BufferVulkan(&context, inputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer, true, FROM_HOST_TO_DEVICE),
+        .weightsBuffer = BufferVulkan(&context, weightsBufferSize, vk::BufferUsageFlagBits::eStorageBuffer, false, FROM_HOST_TO_DEVICE),
+        .outputBuffer = BufferVulkan(&context, outputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer, true, FROM_DEVICE_TO_HOST),
+        .metadataBuffer = BufferVulkan(&context, metadataBufferSize, vk::BufferUsageFlagBits::eUniformBuffer, false, FROM_HOST_TO_DEVICE)
     };
 
     size_t shaderSize;
@@ -267,7 +308,7 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType,
     }
 
     vk::ShaderModuleCreateInfo ShaderModuleCreateInfo(vk::ShaderModuleCreateFlags(), shaderSize, (uint32_t*)mm.shaderData);
-    mm.shaderModule = context->device.createShaderModule(ShaderModuleCreateInfo);
+    mm.shaderModule = context.device.createShaderModule(ShaderModuleCreateInfo);
 
     const std::vector<vk::DescriptorSetLayoutBinding> descriptorSetLayoutBinding = {
         {0, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
@@ -276,30 +317,30 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType,
         {3, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eCompute}
     };
     vk::DescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(vk::DescriptorSetLayoutCreateFlags(), descriptorSetLayoutBinding);
-    mm.descriptorSetLayout = context->device.createDescriptorSetLayout(descriptorSetLayoutCreateInfo);
+    mm.descriptorSetLayout = context.device.createDescriptorSetLayout(descriptorSetLayoutCreateInfo);
 
     vk::PipelineLayoutCreateInfo pipelineLayoutCreateInfo(vk::PipelineLayoutCreateFlags(), mm.descriptorSetLayout);
-    mm.pipelineLayout = context->device.createPipelineLayout(pipelineLayoutCreateInfo);
-    mm.pipelineCache = context->device.createPipelineCache(vk::PipelineCacheCreateInfo());
+    mm.pipelineLayout = context.device.createPipelineLayout(pipelineLayoutCreateInfo);
+    mm.pipelineCache = context.device.createPipelineCache(vk::PipelineCacheCreateInfo());
 
     vk::PipelineShaderStageCreateInfo pipelineShaderCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eCompute, mm.shaderModule, "main");
     vk::ComputePipelineCreateInfo computePipelineCreateInfo(vk::PipelineCreateFlags(), pipelineShaderCreateInfo, mm.pipelineLayout);
-    mm.computePipeline = context->device.createComputePipeline(mm.pipelineCache, computePipelineCreateInfo).value;
+    mm.computePipeline = context.device.createComputePipeline(mm.pipelineCache, computePipelineCreateInfo).value;
 
     vk::DescriptorPoolSize descriptorPoolSizes[2];
     descriptorPoolSizes[0] = { vk::DescriptorType::eStorageBuffer, 3 };
     descriptorPoolSizes[1] = { vk::DescriptorType::eUniformBuffer, 1 };
 
     vk::DescriptorPoolCreateInfo descriptorPoolCreateInfo(vk::DescriptorPoolCreateFlags(), 2, descriptorPoolSizes);
-    mm.descriptorPool = context->device.createDescriptorPool(descriptorPoolCreateInfo);
+    mm.descriptorPool = context.device.createDescriptorPool(descriptorPoolCreateInfo);
 
     vk::DescriptorSetAllocateInfo descriptorSetAllocInfo(mm.descriptorPool, 1, &mm.descriptorSetLayout);
-    const std::vector<vk::DescriptorSet> descriptorSets = context->device.allocateDescriptorSets(descriptorSetAllocInfo);
+    const std::vector<vk::DescriptorSet> descriptorSets = context.device.allocateDescriptorSets(descriptorSetAllocInfo);
     vk::DescriptorSet descriptorSet = descriptorSets.front();
-    vk::DescriptorBufferInfo inputBufferInfo(mm.inputBuffer.buffer, 0, inputBufferSize);
-    vk::DescriptorBufferInfo weightsBufferInfo(mm.weightsBuffer.buffer, 0, weightsBufferSize);
-    vk::DescriptorBufferInfo outputBufferInfo(mm.outputBuffer.buffer, 0, outputBufferSize);
-    vk::DescriptorBufferInfo metadataBufferInfo(mm.metadataBuffer.buffer, 0, metadataBufferSize);
+    vk::DescriptorBufferInfo inputBufferInfo(mm.inputBuffer.deviceBuffer, 0, inputBufferSize);
+    vk::DescriptorBufferInfo weightsBufferInfo(mm.weightsBuffer.deviceBuffer, 0, weightsBufferSize);
+    vk::DescriptorBufferInfo outputBufferInfo(mm.outputBuffer.deviceBuffer, 0, outputBufferSize);
+    vk::DescriptorBufferInfo metadataBufferInfo(mm.metadataBuffer.deviceBuffer, 0, metadataBufferSize);
 
     const std::vector<vk::WriteDescriptorSet> writeDescriptorSets = {
         {descriptorSet, 0, 0, 1, vk::DescriptorType::eStorageBuffer, nullptr, &inputBufferInfo},
@@ -307,10 +348,10 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType,
         {descriptorSet, 2, 0, 1, vk::DescriptorType::eStorageBuffer, nullptr, &outputBufferInfo},
         {descriptorSet, 3, 0, 1, vk::DescriptorType::eUniformBuffer, nullptr, &metadataBufferInfo},
     };
-    context->device.updateDescriptorSets(writeDescriptorSets, {});
+    context.device.updateDescriptorSets(writeDescriptorSets, {});
 
-    vk::CommandBufferAllocateInfo commandBufferAllocInfo(context->commandPool, vk::CommandBufferLevel::ePrimary, 1);
-    const std::vector<vk::CommandBuffer> cmdBuffers = context->device.allocateCommandBuffers(commandBufferAllocInfo);
+    vk::CommandBufferAllocateInfo commandBufferAllocInfo(context.commandPool, vk::CommandBufferLevel::ePrimary, 1);
+    const std::vector<vk::CommandBuffer> cmdBuffers = context.device.allocateCommandBuffers(commandBufferAllocInfo);
     mm.commandBuffer = cmdBuffers.front();
 
     mm.commandBuffer.begin({ vk::CommandBufferUsageFlags{} });
@@ -320,10 +361,10 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType,
     mm.commandBuffer.dispatch(1, d, 1);
     mm.commandBuffer.end();
 
-    mm.fence = context->device.createFence(vk::FenceCreateInfo());
+    mm.fence = context.device.createFence(vk::FenceCreateInfo());
 
     uint32_t metadata = (uint32_t)n;
-    mm.metadataBuffer.load((const void*)&metadata);
+    mm.metadataBuffer.write((const void*)&metadata);
 
     matmuls.push_back(mm);
     return matmuls.size() - 1;
@@ -331,21 +372,21 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType,
 
 void AcceleratorVulkan::loadMatmulWeights(const unsigned int matmulIndex, const void* weights) {
     auto mm = &matmuls[matmulIndex];
-    mm->weightsBuffer.load(weights);
+    mm->weightsBuffer.write(weights);
 }
 
 void AcceleratorVulkan::beginForwardMatmul(const unsigned int matmulIndex, const void* input) {
     auto mm = &matmuls[matmulIndex];
-    mm->inputBuffer.load(input);
+    mm->inputBuffer.write(input);
 
-    context->device.resetFences({ mm->fence });
+    context.device.resetFences({ mm->fence });
     vk::SubmitInfo submitInfo(0, nullptr, nullptr, 1, &mm->commandBuffer);
-    context->queue.submit({ submitInfo }, mm->fence);
+    context.queue.submit({ submitInfo }, mm->fence);
 }
 
 void AcceleratorVulkan::endForwardMatmul(const unsigned int matmulIndex, float* output) {
     auto mm = &matmuls[matmulIndex];
-    context->device.waitForFences({ mm->fence }, true, uint64_t(-1));
+    context.device.waitForFences({ mm->fence }, true, uint64_t(-1));
 
-    copyFromOrToGpu(context, mm->outputBuffer.bufferSize, false, (void*)output, mm->outputBuffer.buffer);
+    mm->outputBuffer.read((void*)output);
 }

--- a/src/accelerator-vulkan.cpp
+++ b/src/accelerator-vulkan.cpp
@@ -1,0 +1,222 @@
+#include <cstdio>
+#include "utils.hpp"
+#include "accelerator-vulkan.hpp"
+
+bool hasPortabilityExtension() {
+#ifdef __APPLE__
+    const std::vector<vk::ExtensionProperties> extensionProperties = vk::enumerateInstanceExtensionProperties();
+    for (const auto& extension : extensionProperties) {
+        if (strcmp(extension.extensionName, "VK_KHR_portability_enumeration") == 0)
+            return true;
+    }
+#endif
+    return false;
+}
+
+bool hasValidationLayer() {
+    const std::vector<vk::LayerProperties> layerProperties = vk::enumerateInstanceLayerProperties();
+    for (const auto& layer : layerProperties) {
+        if (strcmp(layer.layerName, "VK_LAYER_KHRONOS_validation") == 0)
+            return true;
+    }
+    return false;
+}
+
+char* readShaderFile(const char* path, size_t* fileSize) {
+    FILE* fd = fopen(path, "rb");
+    if (fd == NULL)
+        throw new std::runtime_error("Cannot open shader file");
+    *fileSize = seekToEnd(fd);
+    rewind(fd);
+    char* buffer = new char[*fileSize];
+    if (fread(buffer, *fileSize, 1, fd) != 1)
+        throw std::runtime_error("Cannot read shader file");
+    return buffer;
+}
+
+BufferVulkan createBuffer(
+    vk::PhysicalDevice& physicalDevice,
+    vk::Device& device,
+    vk::MemoryPropertyFlags memFlagBits,
+    const uint32_t& computeQueueFamilyIndex,
+    const uint32_t bufferSize,
+    vk::BufferUsageFlags usageFlags
+) {
+    vk::PhysicalDeviceMemoryProperties memoryProperties = physicalDevice.getMemoryProperties();
+
+    uint32_t memoryTypeIndex = uint32_t(~0);
+    for (uint32_t index = 0; index < memoryProperties.memoryTypeCount; ++index) {
+        auto flags = memoryProperties.memoryTypes[index].propertyFlags;
+        if ((flags & memFlagBits) == memFlagBits) {
+            memoryTypeIndex = index;
+            break;
+        }
+    }
+    if (memoryTypeIndex == uint32_t(~0))
+        throw std::runtime_error("Cannot find required Vulkan memory type");
+
+    vk::BufferCreateInfo bufferCreateInfo {
+        vk::BufferCreateFlags(), bufferSize, usageFlags,
+        vk::SharingMode::eExclusive, 1, &computeQueueFamilyIndex };
+    vk::Buffer buffer = device.createBuffer(bufferCreateInfo);
+
+    vk::MemoryRequirements memoryRequirements = device.getBufferMemoryRequirements(buffer);
+    vk::MemoryAllocateInfo bufferMemoryAllocateInfo(memoryRequirements.size, memoryTypeIndex);
+    vk::DeviceMemory bufferMemory = device.allocateMemory(bufferMemoryAllocateInfo);
+    device.bindBufferMemory(buffer, bufferMemory, 0);
+    return { bufferSize, buffer, bufferMemory };
+}
+
+void destroyBuffer(vk::Device& device, BufferVulkan& bv) {
+    device.freeMemory(bv.deviceMemory);
+    device.destroyBuffer(bv.buffer);
+}
+
+AcceleratorVulkan::AcceleratorVulkan() {
+    vk::InstanceCreateFlags createInstanceFlags(0);
+    std::vector<const char*> instanceLayers = {};
+    std::vector<const char*> instanceExtensions = {};
+    std::vector<const char*> deviceExtension = {};
+
+    if (hasValidationLayer()) {
+        instanceLayers.push_back("VK_LAYER_KHRONOS_validation");
+    }
+    if (hasPortabilityExtension()) {
+        createInstanceFlags |= vk::InstanceCreateFlagBits::eEnumeratePortabilityKHR;
+        instanceExtensions.push_back("VK_KHR_portability_enumeration");
+        deviceExtension.push_back("VK_KHR_portability_subset");
+    }
+
+    vk::ApplicationInfo appInfo {"Distributed Llama", 1, nullptr, 0, VK_API_VERSION_1_2 };
+    vk::InstanceCreateInfo instanceCreateInfo(createInstanceFlags, &appInfo, instanceLayers, instanceExtensions);
+    instance = vk::createInstance(instanceCreateInfo);
+
+    physicalDevice = instance.enumeratePhysicalDevices()
+        //.back();
+        .front();
+
+    vk::PhysicalDeviceProperties deviceProps = physicalDevice.getProperties();
+    printf("🌋 device: %s\n", (char*)deviceProps.deviceName);
+    printf("🌋 deviceApiVersion: %d.%d.%d\n", VK_VERSION_MAJOR(deviceProps.apiVersion), VK_VERSION_MINOR(deviceProps.apiVersion), VK_VERSION_PATCH(deviceProps.apiVersion));
+
+    std::vector<vk::QueueFamilyProperties> queueFamilyProps = physicalDevice.getQueueFamilyProperties();
+    auto propIt = std::find_if(queueFamilyProps.begin(), queueFamilyProps.end(), [](const vk::QueueFamilyProperties& Prop) {
+        return Prop.queueFlags & vk::QueueFlagBits::eCompute;
+    });
+    queueFamilyIndex = std::distance(queueFamilyProps.begin(), propIt);
+    printf("🌋 queueFamilyIndex: %d\n", queueFamilyIndex);
+
+    const float queuePriority = 1.0f;
+    vk::DeviceQueueCreateInfo deviceQueueCreateInfo(vk::DeviceQueueCreateFlags(), queueFamilyIndex, 1, &queuePriority);
+
+    vk::DeviceCreateInfo deviceCreateInfo(vk::DeviceCreateFlags(), deviceQueueCreateInfo);
+    deviceCreateInfo.enabledExtensionCount = deviceExtension.size();
+    deviceCreateInfo.ppEnabledExtensionNames = deviceExtension.data();
+    device = physicalDevice.createDevice(deviceCreateInfo);
+
+    vk::CommandPoolCreateInfo commandPoolCreateInfo(vk::CommandPoolCreateFlags(vk::CommandPoolCreateFlagBits::eTransient), queueFamilyIndex);
+    commandPool = device.createCommandPool(commandPoolCreateInfo);
+}
+
+AcceleratorVulkan::~AcceleratorVulkan() {
+    for (int m = 0; m < matmuls.size(); m++) {
+        MatmulVulkan* mm = &matmuls[m];
+        destroyBuffer(device, mm->inputBuffer);
+        destroyBuffer(device, mm->weightsBuffer);
+        destroyBuffer(device, mm->outputBuffer);
+        destroyBuffer(device, mm->metadataBuffer);
+
+        device.destroyDescriptorSetLayout(mm->descriptorSetLayout);
+		device.destroyPipelineLayout(mm->pipelineLayout);
+		device.destroyPipelineCache(mm->pipelineCache);
+		device.destroyShaderModule(mm->shaderModule);
+		device.destroyPipeline(mm->computePipeline);
+		device.destroyDescriptorPool(mm->descriptorPool);
+    }
+
+    device.destroyCommandPool(commandPool);
+    device.destroy();
+    instance.destroy();
+}
+
+unsigned int AcceleratorVulkan::allocateMatmul(const FloatType inputFloatType, const FloatType weightsFloatType, const unsigned int n, const unsigned int d) {
+    const uint32_t inputBufferSize = getBatchBytes(inputFloatType, n, 1);
+    const uint32_t weightsBufferSize = getBatchBytes(weightsFloatType, n, d);
+    const uint32_t outputBufferSize = getBatchBytes(F32, d, 1);
+    const uint32_t metadataBufferSize = sizeof(uint32_t);
+
+    MatmulVulkan mm;
+    mm.inputBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
+        queueFamilyIndex, inputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+    mm.weightsBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
+        queueFamilyIndex, weightsBufferSize, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+    mm.outputBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
+        queueFamilyIndex, outputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+    mm.metadataBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
+        queueFamilyIndex, metadataBufferSize, vk::BufferUsageFlagBits::eUniformBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+
+    size_t shaderSize;
+    char* shaderData = readShaderFile("src/vulkan/matmul-q40-q80.spv", &shaderSize);
+    vk::ShaderModuleCreateInfo ShaderModuleCreateInfo(vk::ShaderModuleCreateFlags(), shaderSize, (uint32_t*)shaderData);
+    mm.shaderModule = device.createShaderModule(ShaderModuleCreateInfo);
+    delete[] shaderData;
+
+    const std::vector<vk::DescriptorSetLayoutBinding> descriptorSetLayoutBinding = {
+        {0, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
+        {1, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
+        {2, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
+        {3, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eCompute}
+    };
+    vk::DescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(vk::DescriptorSetLayoutCreateFlags(), descriptorSetLayoutBinding);
+    mm.descriptorSetLayout = device.createDescriptorSetLayout(descriptorSetLayoutCreateInfo);
+
+    vk::PipelineLayoutCreateInfo pipelineLayoutCreateInfo(vk::PipelineLayoutCreateFlags(), mm.descriptorSetLayout);
+    mm.pipelineLayout = device.createPipelineLayout(pipelineLayoutCreateInfo);
+    mm.pipelineCache = device.createPipelineCache(vk::PipelineCacheCreateInfo());
+
+    vk::PipelineShaderStageCreateInfo pipelineShaderCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eCompute, mm.shaderModule, "main");
+    vk::ComputePipelineCreateInfo computePipelineCreateInfo(vk::PipelineCreateFlags(), pipelineShaderCreateInfo, mm.pipelineLayout);
+    mm.computePipeline = device.createComputePipeline(mm.pipelineCache, computePipelineCreateInfo).value;
+
+    vk::DescriptorPoolSize descriptorPoolSizes[2];
+    descriptorPoolSizes[0] = { vk::DescriptorType::eStorageBuffer, 3 };
+    descriptorPoolSizes[1] = { vk::DescriptorType::eUniformBuffer, 1 };
+
+    vk::DescriptorPoolCreateInfo descriptorPoolCreateInfo(vk::DescriptorPoolCreateFlags(), 2, descriptorPoolSizes);
+    mm.descriptorPool = device.createDescriptorPool(descriptorPoolCreateInfo);
+
+    vk::DescriptorSetAllocateInfo descriptorSetAllocInfo(mm.descriptorPool, 1, &mm.descriptorSetLayout);
+    const std::vector<vk::DescriptorSet> descriptorSets = device.allocateDescriptorSets(descriptorSetAllocInfo);
+    vk::DescriptorSet descriptorSet = descriptorSets.front();
+    vk::DescriptorBufferInfo inputBufferInfo(mm.inputBuffer.buffer, 0, inputBufferSize);
+    vk::DescriptorBufferInfo weightsBufferInfo(mm.weightsBuffer.buffer, 0, weightsBufferSize);
+    vk::DescriptorBufferInfo outputBufferInfo(mm.outputBuffer.buffer, 0, outputBufferSize);
+    vk::DescriptorBufferInfo metadataBufferInfo(mm.metadataBuffer.buffer, 0, metadataBufferSize);
+
+    const std::vector<vk::WriteDescriptorSet> writeDescriptorSets = {
+        {descriptorSet, 0, 0, 1, vk::DescriptorType::eStorageBuffer, nullptr, &inputBufferInfo},
+        {descriptorSet, 1, 0, 1, vk::DescriptorType::eStorageBuffer, nullptr, &weightsBufferInfo},
+        {descriptorSet, 2, 0, 1, vk::DescriptorType::eStorageBuffer, nullptr, &outputBufferInfo},
+        {descriptorSet, 3, 0, 1, vk::DescriptorType::eUniformBuffer, nullptr, &metadataBufferInfo},
+    };
+    device.updateDescriptorSets(writeDescriptorSets, {});
+
+    vk::CommandBufferAllocateInfo commandBufferAllocInfo(commandPool, vk::CommandBufferLevel::ePrimary, 1);
+    const std::vector<vk::CommandBuffer> cmdBuffers = device.allocateCommandBuffers(commandBufferAllocInfo);
+    mm.commandBuffer = cmdBuffers.front();
+
+    mm.commandBuffer.begin({ vk::CommandBufferUsageFlags{} });
+
+    mm.commandBuffer.bindPipeline(vk::PipelineBindPoint::eCompute, mm.computePipeline);
+    mm.commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute, mm.pipelineLayout, 0, { descriptorSet }, {});
+    mm.commandBuffer.dispatch(1, d / 4, 1);
+    mm.commandBuffer.end();
+
+    matmuls.push_back(mm);
+    return matmuls.size() - 1;
+}
+
+void AcceleratorVulkan::loadMatmulWeights(const unsigned int matmulIndex, const void* weights) {}
+void AcceleratorVulkan::beginForwardMatmul(const unsigned int matmulIndex, const void* input) {}
+void AcceleratorVulkan::endForwardMatmul(const unsigned int matmulIndex, float* output) {}
+void AcceleratorVulkan::closeMatmul(const unsigned int matmulIndex) {}

--- a/src/accelerator-vulkan.cpp
+++ b/src/accelerator-vulkan.cpp
@@ -22,57 +22,20 @@ bool hasValidationLayer() {
     return false;
 }
 
-char* readShaderFile(const char* path, size_t* fileSize) {
+void readShaderFile(const char* path, char** output, size_t* fileSize) {
     FILE* fd = fopen(path, "rb");
     if (fd == NULL)
-        throw new std::runtime_error("Cannot open shader file");
+        throw std::runtime_error("Cannot open shader file");
     *fileSize = seekToEnd(fd);
     rewind(fd);
-    char* buffer = new char[*fileSize];
-    if (fread(buffer, *fileSize, 1, fd) != 1)
+    assert(*fileSize > 0);
+    *output = new char[*fileSize];
+    if (fread(*output, *fileSize, 1, fd) != 1)
         throw std::runtime_error("Cannot read shader file");
-    return buffer;
+    assert(fclose(fd) == 0);
 }
 
-BufferVulkan createBuffer(
-    vk::PhysicalDevice& physicalDevice,
-    vk::Device& device,
-    vk::MemoryPropertyFlags memFlagBits,
-    const uint32_t& computeQueueFamilyIndex,
-    const uint32_t bufferSize,
-    vk::BufferUsageFlags usageFlags
-) {
-    vk::PhysicalDeviceMemoryProperties memoryProperties = physicalDevice.getMemoryProperties();
-
-    uint32_t memoryTypeIndex = uint32_t(~0);
-    for (uint32_t index = 0; index < memoryProperties.memoryTypeCount; ++index) {
-        auto flags = memoryProperties.memoryTypes[index].propertyFlags;
-        if ((flags & memFlagBits) == memFlagBits) {
-            memoryTypeIndex = index;
-            break;
-        }
-    }
-    if (memoryTypeIndex == uint32_t(~0))
-        throw std::runtime_error("Cannot find required Vulkan memory type");
-
-    vk::BufferCreateInfo bufferCreateInfo {
-        vk::BufferCreateFlags(), bufferSize, usageFlags,
-        vk::SharingMode::eExclusive, 1, &computeQueueFamilyIndex };
-    vk::Buffer buffer = device.createBuffer(bufferCreateInfo);
-
-    vk::MemoryRequirements memoryRequirements = device.getBufferMemoryRequirements(buffer);
-    vk::MemoryAllocateInfo bufferMemoryAllocateInfo(memoryRequirements.size, memoryTypeIndex);
-    vk::DeviceMemory bufferMemory = device.allocateMemory(bufferMemoryAllocateInfo);
-    device.bindBufferMemory(buffer, bufferMemory, 0);
-    return { bufferSize, buffer, bufferMemory };
-}
-
-void destroyBuffer(vk::Device& device, BufferVulkan& bv) {
-    device.freeMemory(bv.deviceMemory);
-    device.destroyBuffer(bv.buffer);
-}
-
-AcceleratorVulkan::AcceleratorVulkan() {
+VulkanContext::VulkanContext() {
     vk::InstanceCreateFlags createInstanceFlags(0);
     std::vector<const char*> instanceLayers = {};
     std::vector<const char*> instanceExtensions = {};
@@ -86,6 +49,8 @@ AcceleratorVulkan::AcceleratorVulkan() {
         instanceExtensions.push_back("VK_KHR_portability_enumeration");
         deviceExtension.push_back("VK_KHR_portability_subset");
     }
+    deviceExtension.push_back("VK_KHR_16bit_storage");
+    deviceExtension.push_back("VK_KHR_shader_float16_int8");
 
     vk::ApplicationInfo appInfo {"Distributed Llama", 1, nullptr, 0, VK_API_VERSION_1_2 };
     vk::InstanceCreateInfo instanceCreateInfo(createInstanceFlags, &appInfo, instanceLayers, instanceExtensions);
@@ -98,6 +63,24 @@ AcceleratorVulkan::AcceleratorVulkan() {
     vk::PhysicalDeviceProperties deviceProps = physicalDevice.getProperties();
     printf("🌋 device: %s\n", (char*)deviceProps.deviceName);
     printf("🌋 deviceApiVersion: %d.%d.%d\n", VK_VERSION_MAJOR(deviceProps.apiVersion), VK_VERSION_MINOR(deviceProps.apiVersion), VK_VERSION_PATCH(deviceProps.apiVersion));
+
+    vk::PhysicalDeviceFeatures deviceFeatures = physicalDevice.getFeatures();
+
+    VkPhysicalDeviceFeatures2 deviceFeatures2;
+    deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    deviceFeatures2.pNext = nullptr;
+    deviceFeatures2.features = (VkPhysicalDeviceFeatures)deviceFeatures;
+
+    VkPhysicalDeviceVulkan11Features vk11Features;
+    vk11Features.pNext = nullptr;
+    vk11Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+    deviceFeatures2.pNext = &vk11Features;
+
+    VkPhysicalDeviceVulkan12Features vk12Features;
+    vk12Features.pNext = nullptr;
+    vk12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+    vk11Features.pNext = &vk12Features;
+    vkGetPhysicalDeviceFeatures2(physicalDevice, &deviceFeatures2);
 
     std::vector<vk::QueueFamilyProperties> queueFamilyProps = physicalDevice.getQueueFamilyProperties();
     auto propIt = std::find_if(queueFamilyProps.begin(), queueFamilyProps.end(), [](const vk::QueueFamilyProperties& Prop) {
@@ -112,54 +95,179 @@ AcceleratorVulkan::AcceleratorVulkan() {
     vk::DeviceCreateInfo deviceCreateInfo(vk::DeviceCreateFlags(), deviceQueueCreateInfo);
     deviceCreateInfo.enabledExtensionCount = deviceExtension.size();
     deviceCreateInfo.ppEnabledExtensionNames = deviceExtension.data();
+    deviceCreateInfo.setPNext(&deviceFeatures2);
     device = physicalDevice.createDevice(deviceCreateInfo);
 
     vk::CommandPoolCreateInfo commandPoolCreateInfo(vk::CommandPoolCreateFlags(vk::CommandPoolCreateFlagBits::eTransient), queueFamilyIndex);
     commandPool = device.createCommandPool(commandPoolCreateInfo);
+
+    queue = device.getQueue(queueFamilyIndex, 0);
 }
 
-AcceleratorVulkan::~AcceleratorVulkan() {
-    for (int m = 0; m < matmuls.size(); m++) {
-        MatmulVulkan* mm = &matmuls[m];
-        destroyBuffer(device, mm->inputBuffer);
-        destroyBuffer(device, mm->weightsBuffer);
-        destroyBuffer(device, mm->outputBuffer);
-        destroyBuffer(device, mm->metadataBuffer);
-
-        device.destroyDescriptorSetLayout(mm->descriptorSetLayout);
-		device.destroyPipelineLayout(mm->pipelineLayout);
-		device.destroyPipelineCache(mm->pipelineCache);
-		device.destroyShaderModule(mm->shaderModule);
-		device.destroyPipeline(mm->computePipeline);
-		device.destroyDescriptorPool(mm->descriptorPool);
-    }
-
+VulkanContext::~VulkanContext() {
     device.destroyCommandPool(commandPool);
     device.destroy();
     instance.destroy();
 }
 
-unsigned int AcceleratorVulkan::allocateMatmul(const FloatType inputFloatType, const FloatType weightsFloatType, const unsigned int n, const unsigned int d) {
+std::pair<vk::Buffer, vk::DeviceMemory> createBuffer(VulkanContext* context, vk::MemoryPropertyFlags memFlagBits, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags) {
+	vk::PhysicalDeviceMemoryProperties memoryProperties = context->physicalDevice.getMemoryProperties();
+
+	uint32_t memoryTypeIndex = uint32_t(~0);
+	for (uint32_t index = 0; index < memoryProperties.memoryTypeCount; ++index) {
+		auto flags = memoryProperties.memoryTypes[index].propertyFlags;
+		if ((flags & memFlagBits) == memFlagBits) {
+			memoryTypeIndex = index;
+			break;
+		}
+	}
+	if (memoryTypeIndex == uint32_t(~0)) {
+		throw std::runtime_error("Cannot find expected memory type");
+	}
+
+	vk::BufferCreateInfo bufferCreateInfo {
+		vk::BufferCreateFlags(), bufferSize, usageFlags,
+		vk::SharingMode::eExclusive, 1, &context->queueFamilyIndex };
+	vk::Buffer buffer = context->device.createBuffer(bufferCreateInfo);
+
+	vk::MemoryRequirements memoryRequirements = context->device.getBufferMemoryRequirements(buffer);
+
+	vk::MemoryAllocateInfo bufferMemoryAllocateInfo(memoryRequirements.size, memoryTypeIndex);
+
+	vk::DeviceMemory bufferMemory = context->device.allocateMemory(bufferMemoryAllocateInfo);
+
+	context->device.bindBufferMemory(buffer, bufferMemory, 0);
+	return std::make_pair(buffer, bufferMemory);
+}
+
+void copyFromOrToGpu(VulkanContext* context, const uint32_t bufferSize, const bool direction, void* data, vk::Buffer& gpuBuffer) {
+	auto br = createBuffer(context, vk::MemoryPropertyFlagBits::eHostVisible, bufferSize, vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+	vk::Buffer hostBuffer = br.first;
+	vk::DeviceMemory hostBufferMemory = br.second;
+
+    if (direction) { // direction = 1 => host -> gpu
+        void* localPtr = context->device.mapMemory(hostBufferMemory, 0, bufferSize);
+        memcpy(localPtr, data, bufferSize);
+        context->device.unmapMemory(hostBufferMemory);
+    }
+
+	vk::CommandBufferAllocateInfo allocInfo(context->commandPool, vk::CommandBufferLevel::ePrimary, 1);
+	const std::vector<vk::CommandBuffer> cmdBuffers = context->device.allocateCommandBuffers(allocInfo);
+	vk::CommandBuffer cmdBuffer = cmdBuffers.front();
+
+	cmdBuffer.begin({ vk::CommandBufferUsageFlags{} });
+
+	VkBufferCopy copyRegion = { 0 };
+	copyRegion.size = bufferSize;
+    if (direction) {
+	    vkCmdCopyBuffer(cmdBuffer, hostBuffer, gpuBuffer, 1, &copyRegion);
+    } else {
+        vkCmdCopyBuffer(cmdBuffer, gpuBuffer, hostBuffer, 1, &copyRegion);
+    }
+	cmdBuffer.end();
+
+	vk::SubmitInfo submitInfo(0, nullptr, nullptr, 1, &cmdBuffer);
+	vk::Fence fence = context->device.createFence(vk::FenceCreateInfo());
+
+	//auto t0 = std::chrono::high_resolution_clock::now();
+
+	context->queue.submit({ submitInfo }, fence);
+	auto result = context->device.waitForFences({ fence }, true, uint64_t(-1));
+
+	//auto t1 = std::chrono::high_resolution_clock::now();
+	//auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+	//printf("copy: %lldms, size: %d kB\n", durationMs, bufferSize / 1024);
+
+    if (!direction) { // direction = 0 => gpu -> host
+        void* localPtr = context->device.mapMemory(hostBufferMemory, 0, bufferSize);
+        memcpy(data, localPtr, bufferSize);
+        context->device.unmapMemory(hostBufferMemory);
+    }
+
+	context->device.destroyFence(fence);
+	context->device.freeCommandBuffers(context->commandPool, 1, &cmdBuffer);
+
+	context->device.freeMemory(hostBufferMemory);
+	context->device.destroyBuffer(hostBuffer);
+}
+
+void copyFromGpuMemory(VulkanContext* context, const uint32_t bufferSize, void* target, vk::DeviceMemory& deviceMemory) {
+    void* gpuMemory = static_cast<float*>(context->device.mapMemory(deviceMemory, 0, bufferSize));
+    memcpy(target, gpuMemory, bufferSize);
+    context->device.unmapMemory(deviceMemory);
+}
+
+BufferVulkan::BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags) {
+    this->context = context;
+    this->bufferSize = bufferSize;
+
+    auto b = createBuffer(context, vk::MemoryPropertyFlagBits::eDeviceLocal, bufferSize, 
+        usageFlags | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+    this->buffer = b.first;
+    this->deviceMemory = b.second;
+}
+
+void BufferVulkan::load(const void* data) {
+    copyFromOrToGpu(context, bufferSize, true, (void*)data, buffer);
+}
+
+void BufferVulkan::destroy() {
+    this->context->device.freeMemory(deviceMemory);
+    this->context->device.destroyBuffer(buffer);
+}
+
+AcceleratorVulkan::AcceleratorVulkan(VulkanContext* context) {
+    this->context = context;
+}
+
+AcceleratorVulkan::~AcceleratorVulkan() {
+    for (int m = 0; m < matmuls.size(); m++) {
+        MatmulVulkan* mm = &matmuls[m];
+        mm->inputBuffer.destroy();
+        mm->weightsBuffer.destroy();
+        mm->outputBuffer.destroy();
+        mm->metadataBuffer.destroy();
+
+        context->device.destroyDescriptorSetLayout(mm->descriptorSetLayout);
+		context->device.destroyPipelineLayout(mm->pipelineLayout);
+		context->device.destroyPipelineCache(mm->pipelineCache);
+		context->device.destroyShaderModule(mm->shaderModule);
+		context->device.destroyPipeline(mm->computePipeline);
+		context->device.destroyDescriptorPool(mm->descriptorPool);
+		context->device.destroyFence(mm->fence);
+
+        delete mm->shaderData;
+    }
+}
+
+unsigned int AcceleratorVulkan::allocateMatmul(const FloatType weightsFloatType, const FloatType inputFloatType, const unsigned int n, const unsigned int d) {
+    assert(n % 32 == 0);
+
     const uint32_t inputBufferSize = getBatchBytes(inputFloatType, n, 1);
     const uint32_t weightsBufferSize = getBatchBytes(weightsFloatType, n, d);
     const uint32_t outputBufferSize = getBatchBytes(F32, d, 1);
     const uint32_t metadataBufferSize = sizeof(uint32_t);
 
-    MatmulVulkan mm;
-    mm.inputBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
-        queueFamilyIndex, inputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
-    mm.weightsBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
-        queueFamilyIndex, weightsBufferSize, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
-    mm.outputBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
-        queueFamilyIndex, outputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
-    mm.metadataBuffer = createBuffer(physicalDevice, device, vk::MemoryPropertyFlagBits::eDeviceLocal,
-        queueFamilyIndex, metadataBufferSize, vk::BufferUsageFlagBits::eUniformBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+    MatmulVulkan mm = {
+        .inputBuffer = BufferVulkan(context, inputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer),
+        .weightsBuffer = BufferVulkan(context, weightsBufferSize, vk::BufferUsageFlagBits::eStorageBuffer),
+        .outputBuffer = BufferVulkan(context, outputBufferSize, vk::BufferUsageFlagBits::eStorageBuffer),
+        .metadataBuffer = BufferVulkan(context, metadataBufferSize, vk::BufferUsageFlagBits::eUniformBuffer)
+    };
 
     size_t shaderSize;
-    char* shaderData = readShaderFile("src/vulkan/matmul-q40-q80.spv", &shaderSize);
-    vk::ShaderModuleCreateInfo ShaderModuleCreateInfo(vk::ShaderModuleCreateFlags(), shaderSize, (uint32_t*)shaderData);
-    mm.shaderModule = device.createShaderModule(ShaderModuleCreateInfo);
-    delete[] shaderData;
+    if (inputFloatType == F32 && weightsFloatType == F32) {
+        readShaderFile("src/vulkan/matmul-f32-f32.spv", &mm.shaderData, &shaderSize);
+    } else if (inputFloatType == Q80 && weightsFloatType == Q40) {
+        readShaderFile("src/vulkan/matmul-q40-q80.spv", &mm.shaderData, &shaderSize);
+    } else if (inputFloatType == F32 && weightsFloatType == Q40) {
+        readShaderFile("src/vulkan/matmul-q40-f32.spv", &mm.shaderData, &shaderSize);
+    } else {
+        throw std::runtime_error("Unsupported float type: " + std::to_string(inputFloatType) + "/" + std::to_string(weightsFloatType));
+    }
+
+    vk::ShaderModuleCreateInfo ShaderModuleCreateInfo(vk::ShaderModuleCreateFlags(), shaderSize, (uint32_t*)mm.shaderData);
+    mm.shaderModule = context->device.createShaderModule(ShaderModuleCreateInfo);
 
     const std::vector<vk::DescriptorSetLayoutBinding> descriptorSetLayoutBinding = {
         {0, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute},
@@ -168,25 +276,25 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType inputFloatType, c
         {3, vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eCompute}
     };
     vk::DescriptorSetLayoutCreateInfo descriptorSetLayoutCreateInfo(vk::DescriptorSetLayoutCreateFlags(), descriptorSetLayoutBinding);
-    mm.descriptorSetLayout = device.createDescriptorSetLayout(descriptorSetLayoutCreateInfo);
+    mm.descriptorSetLayout = context->device.createDescriptorSetLayout(descriptorSetLayoutCreateInfo);
 
     vk::PipelineLayoutCreateInfo pipelineLayoutCreateInfo(vk::PipelineLayoutCreateFlags(), mm.descriptorSetLayout);
-    mm.pipelineLayout = device.createPipelineLayout(pipelineLayoutCreateInfo);
-    mm.pipelineCache = device.createPipelineCache(vk::PipelineCacheCreateInfo());
+    mm.pipelineLayout = context->device.createPipelineLayout(pipelineLayoutCreateInfo);
+    mm.pipelineCache = context->device.createPipelineCache(vk::PipelineCacheCreateInfo());
 
     vk::PipelineShaderStageCreateInfo pipelineShaderCreateInfo(vk::PipelineShaderStageCreateFlags(), vk::ShaderStageFlagBits::eCompute, mm.shaderModule, "main");
     vk::ComputePipelineCreateInfo computePipelineCreateInfo(vk::PipelineCreateFlags(), pipelineShaderCreateInfo, mm.pipelineLayout);
-    mm.computePipeline = device.createComputePipeline(mm.pipelineCache, computePipelineCreateInfo).value;
+    mm.computePipeline = context->device.createComputePipeline(mm.pipelineCache, computePipelineCreateInfo).value;
 
     vk::DescriptorPoolSize descriptorPoolSizes[2];
     descriptorPoolSizes[0] = { vk::DescriptorType::eStorageBuffer, 3 };
     descriptorPoolSizes[1] = { vk::DescriptorType::eUniformBuffer, 1 };
 
     vk::DescriptorPoolCreateInfo descriptorPoolCreateInfo(vk::DescriptorPoolCreateFlags(), 2, descriptorPoolSizes);
-    mm.descriptorPool = device.createDescriptorPool(descriptorPoolCreateInfo);
+    mm.descriptorPool = context->device.createDescriptorPool(descriptorPoolCreateInfo);
 
     vk::DescriptorSetAllocateInfo descriptorSetAllocInfo(mm.descriptorPool, 1, &mm.descriptorSetLayout);
-    const std::vector<vk::DescriptorSet> descriptorSets = device.allocateDescriptorSets(descriptorSetAllocInfo);
+    const std::vector<vk::DescriptorSet> descriptorSets = context->device.allocateDescriptorSets(descriptorSetAllocInfo);
     vk::DescriptorSet descriptorSet = descriptorSets.front();
     vk::DescriptorBufferInfo inputBufferInfo(mm.inputBuffer.buffer, 0, inputBufferSize);
     vk::DescriptorBufferInfo weightsBufferInfo(mm.weightsBuffer.buffer, 0, weightsBufferSize);
@@ -199,24 +307,45 @@ unsigned int AcceleratorVulkan::allocateMatmul(const FloatType inputFloatType, c
         {descriptorSet, 2, 0, 1, vk::DescriptorType::eStorageBuffer, nullptr, &outputBufferInfo},
         {descriptorSet, 3, 0, 1, vk::DescriptorType::eUniformBuffer, nullptr, &metadataBufferInfo},
     };
-    device.updateDescriptorSets(writeDescriptorSets, {});
+    context->device.updateDescriptorSets(writeDescriptorSets, {});
 
-    vk::CommandBufferAllocateInfo commandBufferAllocInfo(commandPool, vk::CommandBufferLevel::ePrimary, 1);
-    const std::vector<vk::CommandBuffer> cmdBuffers = device.allocateCommandBuffers(commandBufferAllocInfo);
+    vk::CommandBufferAllocateInfo commandBufferAllocInfo(context->commandPool, vk::CommandBufferLevel::ePrimary, 1);
+    const std::vector<vk::CommandBuffer> cmdBuffers = context->device.allocateCommandBuffers(commandBufferAllocInfo);
     mm.commandBuffer = cmdBuffers.front();
 
     mm.commandBuffer.begin({ vk::CommandBufferUsageFlags{} });
 
     mm.commandBuffer.bindPipeline(vk::PipelineBindPoint::eCompute, mm.computePipeline);
     mm.commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute, mm.pipelineLayout, 0, { descriptorSet }, {});
-    mm.commandBuffer.dispatch(1, d / 4, 1);
+    mm.commandBuffer.dispatch(1, d, 1);
     mm.commandBuffer.end();
+
+    mm.fence = context->device.createFence(vk::FenceCreateInfo());
+
+    uint32_t metadata = (uint32_t)n;
+    mm.metadataBuffer.load((const void*)&metadata);
 
     matmuls.push_back(mm);
     return matmuls.size() - 1;
 }
 
-void AcceleratorVulkan::loadMatmulWeights(const unsigned int matmulIndex, const void* weights) {}
-void AcceleratorVulkan::beginForwardMatmul(const unsigned int matmulIndex, const void* input) {}
-void AcceleratorVulkan::endForwardMatmul(const unsigned int matmulIndex, float* output) {}
-void AcceleratorVulkan::closeMatmul(const unsigned int matmulIndex) {}
+void AcceleratorVulkan::loadMatmulWeights(const unsigned int matmulIndex, const void* weights) {
+    auto mm = &matmuls[matmulIndex];
+    mm->weightsBuffer.load(weights);
+}
+
+void AcceleratorVulkan::beginForwardMatmul(const unsigned int matmulIndex, const void* input) {
+    auto mm = &matmuls[matmulIndex];
+    mm->inputBuffer.load(input);
+
+    context->device.resetFences({ mm->fence });
+    vk::SubmitInfo submitInfo(0, nullptr, nullptr, 1, &mm->commandBuffer);
+    context->queue.submit({ submitInfo }, mm->fence);
+}
+
+void AcceleratorVulkan::endForwardMatmul(const unsigned int matmulIndex, float* output) {
+    auto mm = &matmuls[matmulIndex];
+    context->device.waitForFences({ mm->fence }, true, uint64_t(-1));
+
+    copyFromOrToGpu(context, mm->outputBuffer.bufferSize, false, (void*)output, mm->outputBuffer.buffer);
+}

--- a/src/accelerator-vulkan.cpp
+++ b/src/accelerator-vulkan.cpp
@@ -82,7 +82,7 @@ VulkanContext::VulkanContext() {
     vk::PhysicalDeviceMemoryProperties memoryProperties = physicalDevice.getMemoryProperties();
     for (unsigned int h = 0; h < memoryProperties.memoryHeapCount; h++) {
         if (memoryProperties.memoryHeaps[h].flags & vk::MemoryHeapFlagBits::eDeviceLocal)
-            printf("🌋 heap[%u]: %llu MB\n", h, memoryProperties.memoryHeaps[h].size / (1024 * 1024));
+            printf("🌋 heap[%u]: %lu MB\n", h, ((unsigned long)memoryProperties.memoryHeaps[h].size) / (1024 * 1024));
     }
 
     vk::PhysicalDeviceFeatures deviceFeatures = physicalDevice.getFeatures();

--- a/src/accelerator-vulkan.hpp
+++ b/src/accelerator-vulkan.hpp
@@ -4,10 +4,29 @@
 #include <vulkan/vulkan.hpp>
 #include "accelerator.hpp"
 
-struct BufferVulkan {
+class VulkanContext {
+public:
+    vk::Instance instance;
+    vk::PhysicalDevice physicalDevice;
+    vk::Device device;
+    uint32_t queueFamilyIndex;
+    vk::CommandPool commandPool;
+    vk::Queue queue;
+
+    VulkanContext();
+    ~VulkanContext();
+};
+
+class BufferVulkan {
+public:
+    VulkanContext* context;
     size_t bufferSize;
     vk::Buffer buffer;
     vk::DeviceMemory deviceMemory;
+
+    BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags);
+    void load(const void* data);
+    void destroy();
 };
 
 struct MatmulVulkan {
@@ -21,27 +40,23 @@ struct MatmulVulkan {
     vk::PipelineCache pipelineCache;
     vk::PipelineLayout pipelineLayout;
     vk::ShaderModule shaderModule;
+    char* shaderData;
     vk::CommandBuffer commandBuffer;
+    vk::Fence fence;
 };
 
 class AcceleratorVulkan : public Accelerator {
 private:
-    vk::Instance instance;
-    vk::PhysicalDevice physicalDevice;
-    vk::Device device;
-    uint32_t queueFamilyIndex;
-    vk::CommandPool commandPool;
-
+    VulkanContext* context;
     std::vector<MatmulVulkan> matmuls;
 
 public:
-    AcceleratorVulkan();
+    AcceleratorVulkan(VulkanContext* context);
     ~AcceleratorVulkan();
-    unsigned int allocateMatmul(const FloatType inputFloatType, const FloatType weightsFloatType, const unsigned int n, const unsigned int d);
+    unsigned int allocateMatmul(const FloatType weightsFloatType, const FloatType inputFloatType, const unsigned int n, const unsigned int d);
     void loadMatmulWeights(const unsigned int matmulIndex, const void* weights);
     void beginForwardMatmul(const unsigned int matmulIndex, const void* input);
     void endForwardMatmul(const unsigned int matmulIndex, float* output);
-    void closeMatmul(const unsigned int matmulIndex);
 };
 
 #endif

--- a/src/accelerator-vulkan.hpp
+++ b/src/accelerator-vulkan.hpp
@@ -17,15 +17,38 @@ public:
     ~VulkanContext();
 };
 
+enum CopyBufferVulkanDirection {
+    FROM_HOST_TO_DEVICE,
+    FROM_DEVICE_TO_HOST
+};
+
+class CopyBufferVulkan {
+public:
+    VulkanContext* context;
+    uint32_t bufferSize;
+    vk::Buffer deviceBuffer;
+    vk::Buffer hostBuffer;
+    vk::DeviceMemory hostMemory;
+    vk::Fence fence;
+    vk::CommandBuffer commandBuffer;
+    bool direction;
+    CopyBufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::Buffer& deviceBuffer, CopyBufferVulkanDirection direction);
+    ~CopyBufferVulkan();
+    void copy(void* data);
+};
+
 class BufferVulkan {
 public:
     VulkanContext* context;
     size_t bufferSize;
-    vk::Buffer buffer;
+    vk::Buffer deviceBuffer;
     vk::DeviceMemory deviceMemory;
+    bool isHostVisible;
+    CopyBufferVulkan* copy;
 
-    BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags);
-    void load(const void* data);
+    BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags, bool fastCopy, CopyBufferVulkanDirection direction);
+    void write(const void* data);
+    void read(void* data);
     void destroy();
 };
 
@@ -47,11 +70,11 @@ struct MatmulVulkan {
 
 class AcceleratorVulkan : public Accelerator {
 private:
-    VulkanContext* context;
+    VulkanContext context;
     std::vector<MatmulVulkan> matmuls;
 
 public:
-    AcceleratorVulkan(VulkanContext* context);
+    AcceleratorVulkan();
     ~AcceleratorVulkan();
     unsigned int allocateMatmul(const FloatType weightsFloatType, const FloatType inputFloatType, const unsigned int n, const unsigned int d);
     void loadMatmulWeights(const unsigned int matmulIndex, const void* weights);

--- a/src/accelerator-vulkan.hpp
+++ b/src/accelerator-vulkan.hpp
@@ -32,6 +32,7 @@ public:
     vk::Fence fence;
     vk::CommandBuffer commandBuffer;
     bool direction;
+    void *hostPointer;
     CopyBufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::Buffer& deviceBuffer, CopyBufferVulkanDirection direction);
     ~CopyBufferVulkan();
     void copy(void* data);
@@ -45,6 +46,7 @@ public:
     vk::DeviceMemory deviceMemory;
     bool isHostVisible;
     CopyBufferVulkan* copy;
+    void *hostPointer;
 
     BufferVulkan(VulkanContext* context, const uint32_t bufferSize, vk::BufferUsageFlags usageFlags, bool fastCopy, CopyBufferVulkanDirection direction);
     void write(const void* data);

--- a/src/accelerator-vulkan.hpp
+++ b/src/accelerator-vulkan.hpp
@@ -1,0 +1,47 @@
+#ifndef ACCELERATOR_VULKAN_HPP
+#define ACCELERATOR_VULKAN_HPP
+
+#include <vulkan/vulkan.hpp>
+#include "accelerator.hpp"
+
+struct BufferVulkan {
+    size_t bufferSize;
+    vk::Buffer buffer;
+    vk::DeviceMemory deviceMemory;
+};
+
+struct MatmulVulkan {
+    BufferVulkan inputBuffer;
+    BufferVulkan weightsBuffer;
+    BufferVulkan outputBuffer;
+    BufferVulkan metadataBuffer;
+    vk::DescriptorSetLayout descriptorSetLayout;
+    vk::DescriptorPool descriptorPool;
+    vk::Pipeline computePipeline;
+    vk::PipelineCache pipelineCache;
+    vk::PipelineLayout pipelineLayout;
+    vk::ShaderModule shaderModule;
+    vk::CommandBuffer commandBuffer;
+};
+
+class AcceleratorVulkan : public Accelerator {
+private:
+    vk::Instance instance;
+    vk::PhysicalDevice physicalDevice;
+    vk::Device device;
+    uint32_t queueFamilyIndex;
+    vk::CommandPool commandPool;
+
+    std::vector<MatmulVulkan> matmuls;
+
+public:
+    AcceleratorVulkan();
+    ~AcceleratorVulkan();
+    unsigned int allocateMatmul(const FloatType inputFloatType, const FloatType weightsFloatType, const unsigned int n, const unsigned int d);
+    void loadMatmulWeights(const unsigned int matmulIndex, const void* weights);
+    void beginForwardMatmul(const unsigned int matmulIndex, const void* input);
+    void endForwardMatmul(const unsigned int matmulIndex, float* output);
+    void closeMatmul(const unsigned int matmulIndex);
+};
+
+#endif

--- a/src/accelerator.hpp
+++ b/src/accelerator.hpp
@@ -1,0 +1,16 @@
+#ifndef ACCELERATOR_HPP
+#define ACCELERATOR_HPP
+
+#include "quants.hpp"
+
+class Accelerator {
+public:
+    virtual ~Accelerator() {}
+    virtual unsigned int allocateMatmul(const FloatType inputFloatType, const FloatType weightsFloatType, const unsigned int n, const unsigned int d) = 0;
+    virtual void loadMatmulWeights(const unsigned int matmulIndex, const void* weights) = 0;
+    virtual void beginForwardMatmul(const unsigned int matmulIndex, const void* input) = 0;
+    virtual void endForwardMatmul(const unsigned int matmulIndex, float* output) = 0;
+    virtual void closeMatmul(const unsigned int matmulIndex) = 0;
+};
+
+#endif

--- a/src/accelerator.hpp
+++ b/src/accelerator.hpp
@@ -6,11 +6,10 @@
 class Accelerator {
 public:
     virtual ~Accelerator() {}
-    virtual unsigned int allocateMatmul(const FloatType inputFloatType, const FloatType weightsFloatType, const unsigned int n, const unsigned int d) = 0;
+    virtual unsigned int allocateMatmul(const FloatType weightsFloatType, const FloatType inputFloatType, const unsigned int n, const unsigned int d) = 0;
     virtual void loadMatmulWeights(const unsigned int matmulIndex, const void* weights) = 0;
     virtual void beginForwardMatmul(const unsigned int matmulIndex, const void* input) = 0;
     virtual void endForwardMatmul(const unsigned int matmulIndex, float* output) = 0;
-    virtual void closeMatmul(const unsigned int matmulIndex) = 0;
 };
 
 #endif

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -20,7 +20,7 @@ FloatType parseFloatType(char* val) {
 }
 
 void parseAcceleratorRatio(const char* val, unsigned int* nominator, unsigned* denominator) {
-    const char* sep = strchr(val, '/');
+    const char* sep = strstr(val, "/");
     if (sep == NULL)
         throw std::runtime_error("Cannot parse accelerator ratio");
     size_t pos = sep - val;

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -125,10 +125,11 @@ void App::run(AppArgs* args, void (*program)(Inference* inference, SocketPool* s
     Accelerator* accelerator = NULL;
     unsigned int accNominator = 0;
 #ifdef DLLAMA_VULKAN
-    accelerator = new AcceleratorVulkan();
-    accNominator = 16;
+    VulkanContext vulkanContext = VulkanContext();
+    accelerator = new AcceleratorVulkan(&vulkanContext);
+    accNominator = 32;
 #endif
-    AcceleratorContext acc(0, 32, accelerator);
+    AcceleratorContext acc(accNominator, 32, accelerator);
     Transformer transformer = Transformer::loadRootFromFile(args->modelPath, &spec, socketPool, &acc);
     socketPool->setTurbo(true);
 

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -32,6 +32,8 @@ public:
     pos_t steps;
     bool benchmark;
     unsigned long long seed;
+    unsigned int acceleratorNominator;
+    unsigned int acceleratorDenominator;
 
     // worker
     int port;

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -41,6 +41,14 @@ public:
     static AppArgs parse(int argc, char** argv, bool hasMode);
 };
 
+class AcceleratorManager {
+public:
+    Accelerator* accelerator;
+    AcceleratorContext* context;
+    AcceleratorManager(AppArgs* args);
+    ~AcceleratorManager();
+};
+
 class TransformerArchFactory {
 public:
     static TransformerArch create(TransformerSpec* spec);

--- a/src/apps/dllama/dllama.cpp
+++ b/src/apps/dllama/dllama.cpp
@@ -210,8 +210,8 @@ void worker(AppArgs* args) {
     SocketServer server(args->port);
     Socket socket = server.accept();
     TransformerSpec spec;
-    AcceleratorContext acc(0, 1, NULL);
-    Transformer transformer = Transformer::loadSlice(&spec, &socket, &acc);
+    AcceleratorManager acceleratorManager(args);
+    Transformer transformer = Transformer::loadSlice(&spec, &socket, acceleratorManager.context);
     TransformerArch arch = TransformerArchFactory::create(&spec);
 
     Worker worker = Worker(&arch, args->nThreads, &transformer, &socket);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -152,17 +152,23 @@ size_t MatmulCommand::loadWeights(const void* source) {
     return cpuSize + accSize;
 }
 
-void MatmulCommand::forward(const void* input, float* output, const unsigned int nThreads, const unsigned int threadIndex) {
+void MatmulCommand::begin(const void* input, const unsigned int threadIndex) {
     if (accD != 0 && threadIndex == 0) {
         acc->accelerator->beginForwardMatmul(accMatmulIndex, input);
     }
-    if (cpuD != 0) {
-        matmul(weightsFloatType, inputFloatType, output, input, cpuWeights, n, cpuD, nThreads, threadIndex);
-    }
+}
+
+void MatmulCommand::end(float* output, const unsigned int threadIndex) {
     if (accD != 0 && threadIndex == 0) {
         float* gpuOutput = &output[cpuD];
         acc->accelerator->endForwardMatmul(accMatmulIndex, gpuOutput);
         // DEBUG_FLOATS("gpu", gpuOutput, 8);
+    }
+}
+
+void MatmulCommand::forward(const void* input, float* output, const unsigned int nThreads, const unsigned int threadIndex) {
+    if (cpuD != 0) {
+        matmul(weightsFloatType, inputFloatType, output, input, cpuWeights, n, cpuD, nThreads, threadIndex);
     }
 }
 

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -102,7 +102,7 @@ private:
     unsigned int accMatmulIndex;
     AcceleratorContext* acc;
 public:
-    MatmulCommand(const unsigned int n, const unsigned int d, const FloatType inputFloatType, const FloatType weightsFloatType, AcceleratorContext* acc);
+    MatmulCommand(const unsigned int n, const unsigned int d, const FloatType weightsFloatType, const FloatType inputFloatType, AcceleratorContext* acc);
     ~MatmulCommand();
     size_t loadWeights(const void* source);
     void forward(const void* input, float* output, const unsigned int nThreads, const unsigned int threadIndex);

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -105,6 +105,8 @@ public:
     MatmulCommand(const unsigned int n, const unsigned int d, const FloatType weightsFloatType, const FloatType inputFloatType, AcceleratorContext* acc);
     ~MatmulCommand();
     size_t loadWeights(const void* source);
+    void begin(const void* input, const unsigned int threadIndex);
+    void end(float* output, const unsigned int threadIndex);
     void forward(const void* input, float* output, const unsigned int nThreads, const unsigned int threadIndex);
 };
 

--- a/src/commands.hpp
+++ b/src/commands.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include "quants.hpp"
+#include "accelerator.hpp"
 
 // RESPONSIBILITIES
 //
@@ -73,15 +74,6 @@ public:
     unsigned int nHeads0;
     size_t attSize;
     MultiHeadAttSlice(unsigned int nHeads, unsigned int seqLen, unsigned int nSlices, slice_index_t sliceIndex);
-};
-
-class Accelerator {
-public:
-    virtual const unsigned int allocateMatmul(const FloatType floatType, const unsigned int n, const unsigned int d) = 0;
-    virtual void loadMatmulWeights(const unsigned int matmulIndex, const void* weights) = 0;
-    virtual void beginForwardMatmul(const unsigned int matmulIndex, const void* input) = 0;
-    virtual void endForwardMatmul(const unsigned int matmulIndex, float* output) = 0;
-    virtual void closeMatmul(const unsigned int matmulIndex) = 0;
 };
 
 class AcceleratorContext {

--- a/src/funcs.cpp
+++ b/src/funcs.cpp
@@ -211,7 +211,7 @@ void matmulF16(const MatmulThreadInfo* a) {
 }
 
 void matmulQ40(const MatmulThreadInfo* a) {
-    const int blocksPerRow = 8;
+    const int blocksPerRow = 1; // TODO: remove this variable
     const int k = QK40 * blocksPerRow;
     BlockQ40* w = (BlockQ40*)a->weights;
     assert(a->n % k == 0);

--- a/src/grok1-tasks.cpp
+++ b/src/grok1-tasks.cpp
@@ -138,8 +138,15 @@ void grokMoeBlock0(TASK_ARGS) {
         float* expertUp = &hb[block->moeUpAndGate0Slice->d0 * ae];
         float* expertGate = &block->expertGate[block->moeUpAndGate0Slice->d0 * ae];
 
+
+        block->moeUpMm[e]->begin(xb, threadIndex);
+        block->moeGateMm[e]->begin(xb, threadIndex);
+
         block->moeUpMm[e]->forward(xb, expertUp, nThreads, threadIndex);
         block->moeGateMm[e]->forward(xb, expertGate, nThreads, threadIndex);
+
+        block->moeUpMm[e]->end(expertUp, threadIndex);
+        block->moeGateMm[e]->end(expertGate, threadIndex);
     }
 }
 
@@ -218,7 +225,9 @@ void grokMoeBlock2(TASK_ARGS) {
         char* expertUp = &hbq[rowBytes * ae];
         float* expertDown = ae == 0 ? xb2 : &block->expertDown[block->moeDown0Slice->d0 * (ae - 1)];
 
+        block->moeDownMm[e]->begin(expertUp, threadIndex);
         block->moeDownMm[e]->forward(expertUp, expertDown, nThreads, threadIndex);
+        block->moeDownMm[e]->end(expertDown, threadIndex);
 
         mulScalar(expertDown, weight, block->moeDown0Slice->d0, nThreads, threadIndex);
         if (ae > 0) {

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -217,7 +217,7 @@ Transformer::Transformer(TransformerSpec* spec, slice_index_t sliceIndex, Accele
         tokenEmbeddingTable = (float*)newBuffer(tokenEmbeddingTableBytes);
         rmsFinal = (float*)newBuffer(rmsFinalBytes);
 
-        wclsMm = new MatmulCommand(spec->dim, spec->vocabSize, F32, spec->weightsFloatType, acc);
+        wclsMm = new MatmulCommand(spec->dim, spec->vocabSize, spec->weightsFloatType, F32, acc);
 
         x = (float*)newBuffer(spec->dim * sizeof(float));
         logits = (float*)newBuffer(spec->vocabSize * sizeof(float));
@@ -289,10 +289,10 @@ TransformerBlock::TransformerBlock(TransformerSpec* spec, slice_index_t sliceInd
     v0Slice = new RowMatmulSlice(spec->weightsFloatType, spec->nSlices, spec->dim, spec->kvDim);
     wo0Slice = new ColMatmulSlice(spec->weightsFloatType, spec->nSlices, spec->dim, spec->dim);
 
-    q0mm = new MatmulCommand(q0Slice->n, q0Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
-    k0mm = new MatmulCommand(k0Slice->n, k0Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
-    v0mm = new MatmulCommand(v0Slice->n, v0Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
-    wo0mm = new MatmulCommand(wo0Slice->n0, wo0Slice->d, spec->bufferFloatType, spec->weightsFloatType, acc);
+    q0mm = new MatmulCommand(q0Slice->n, q0Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
+    k0mm = new MatmulCommand(k0Slice->n, k0Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
+    v0mm = new MatmulCommand(v0Slice->n, v0Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
+    wo0mm = new MatmulCommand(wo0Slice->n0, wo0Slice->d, spec->weightsFloatType, spec->bufferFloatType, acc);
 
     qo0 = (float*)newBuffer(q0Slice->d0 * sizeof(float));
 
@@ -305,12 +305,12 @@ TransformerBlock::TransformerBlock(TransformerSpec* spec, slice_index_t sliceInd
         moeUpMm = new MatmulCommand*[spec->nExperts];
         moeGateMm = new MatmulCommand*[spec->nExperts];
         moeDownMm = new MatmulCommand*[spec->nExperts];
-        moeRouterMm = new MatmulCommand(spec->dim, spec->nExperts, F32, spec->weightsFloatType, acc);
+        moeRouterMm = new MatmulCommand(spec->dim, spec->nExperts, spec->weightsFloatType, F32, acc);
 
         for (int e = 0; e < spec->nExperts; e++) {
-            moeUpMm[e] = new MatmulCommand(moeUpAndGate0Slice->n, moeUpAndGate0Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
-            moeGateMm[e] = new MatmulCommand(moeUpAndGate0Slice->n, moeUpAndGate0Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
-            moeDownMm[e] = new MatmulCommand(moeDown0Slice->n, moeDown0Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
+            moeUpMm[e] = new MatmulCommand(moeUpAndGate0Slice->n, moeUpAndGate0Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
+            moeGateMm[e] = new MatmulCommand(moeUpAndGate0Slice->n, moeUpAndGate0Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
+            moeDownMm[e] = new MatmulCommand(moeDown0Slice->n, moeDown0Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
         }
 
         expertGate = (float*)newBuffer(moeUpAndGate0Slice->d0 * spec->nExperts * sizeof(float));
@@ -320,9 +320,9 @@ TransformerBlock::TransformerBlock(TransformerSpec* spec, slice_index_t sliceInd
         w20Slice = new ColMatmulSlice(spec->weightsFloatType, spec->nSlices, spec->hiddenDim, spec->dim);
         w30Slice = new RowMatmulSlice(spec->weightsFloatType, spec->nSlices, spec->dim, spec->hiddenDim);
 
-        w10mm = new MatmulCommand(w10Slice->n, w10Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
-        w20mm = new MatmulCommand(w20Slice->n0, w20Slice->d, spec->bufferFloatType, spec->weightsFloatType, acc);
-        w30mm = new MatmulCommand(w30Slice->n, w30Slice->d0, spec->bufferFloatType, spec->weightsFloatType, acc);
+        w10mm = new MatmulCommand(w10Slice->n, w10Slice->d0, spec->weightsFloatType, spec->bufferFloatType,acc);
+        w20mm = new MatmulCommand(w20Slice->n0, w20Slice->d, spec->weightsFloatType, spec->bufferFloatType, acc);
+        w30mm = new MatmulCommand(w30Slice->n, w30Slice->d0, spec->weightsFloatType, spec->bufferFloatType, acc);
 
         hb20 = (float*)newBuffer(w30Slice->d0 * sizeof(float));
     }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -16,7 +16,7 @@
     const unsigned int varStart = threadIndex * rangeSlice + (threadIndex < rangeRest ? threadIndex : rangeRest); \
     const unsigned int varEnd = varStart + rangeSlice + (threadIndex < rangeRest ? 1 : 0);
 
-#define DEBUG_FLOATS(name, v, n) printf("⭕ %s ", name); for (int i = 0; i < n; i++) printf("%f ", v[i]); printf("\n");
+#define DEBUG_FLOATS(name, v, n) printf("⭕ %s ", name); for (int i = 0; i < n; i++) printf("%.3f ", v[i]); printf("\n");
 
 void* newBuffer(size_t size);
 void freeBuffer(void* buffer);

--- a/src/vulkan/matmul-f32-f32.comp
+++ b/src/vulkan/matmul-f32-f32.comp
@@ -1,0 +1,39 @@
+#version 450
+
+#define FLOAT_TYPE float
+#define N_THREADS 32
+
+layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer inputBuffer { FLOAT_TYPE inpt[]; };
+layout(binding = 1) readonly buffer weightsBuffer { FLOAT_TYPE weights[]; };
+layout(binding = 2) writeonly buffer outputBuffer { FLOAT_TYPE outp[]; };
+layout(binding = 3) readonly uniform metadataBuffer { uint n; };
+
+shared float temp[N_THREADS];
+
+void main() {
+    const uint nn = n / N_THREADS;
+    const uint threadIndex = uint(gl_LocalInvocationID.x);
+    const uint d = uint(gl_GlobalInvocationID.y);
+    const uint iOffset = threadIndex * nn;
+    const uint wOffset = d * n + iOffset;
+
+    float s = 0.0;
+    for (uint i = 0; i < nn; i++) {
+        s += inpt[iOffset + i] * weights[wOffset + i];
+    }
+    temp[threadIndex] = s;
+
+    barrier();
+
+    for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
+        if (threadIndex < i)
+            temp[threadIndex] += temp[threadIndex + i];
+        barrier();
+    }
+
+    if (threadIndex == 0) {
+        outp[d] = temp[0];
+    }
+}

--- a/src/vulkan/matmul-q40-f32.comp
+++ b/src/vulkan/matmul-q40-f32.comp
@@ -1,5 +1,6 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
@@ -38,7 +39,7 @@ void main() {
     for (uint i = start; i < end; i++) {
         uint io = i * QK_40;
         float s0 = 0.0;
-        for (uint j = 0; j < QK_40 / 2; j++) {
+        [[unroll]] for (uint j = 0; j < QK_40 / 2; j++) {
             float i0 = inpt[io + j];
             float i1 = inpt[io + j + QK_40 / 2];
 
@@ -54,7 +55,7 @@ void main() {
 
     barrier();
 
-    for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
+    [[unroll]] for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
         if (threadIndex < i)
             temp[threadIndex] += temp[threadIndex + i];
         barrier();

--- a/src/vulkan/matmul-q40-f32.comp
+++ b/src/vulkan/matmul-q40-f32.comp
@@ -36,18 +36,19 @@ void main() {
 
     float s = 0.0;
     for (uint i = start; i < end; i++) {
-        float ws = float(weights[wOffset + i].d);
         uint io = i * QK_40;
+        float s0 = 0.0;
         for (uint j = 0; j < QK_40 / 2; j++) {
             float i0 = inpt[io + j];
             float i1 = inpt[io + j + QK_40 / 2];
 
             uint wq = uint(weights[wOffset + i].qs[j]);
-            float w0 = ((wq & 0xF) - 8.0f);
-            float w1 = ((wq >>  4) - 8.0f);
+            float w0 = (wq & 0xF) - 8.0f;
+            float w1 = (wq >>  4) - 8.0f;
 
-            s += (i0 * w0 + i1 * w1) * ws;
+            s0 += i0 * w0 + i1 * w1;
         }
+        s += s0 * float(weights[wOffset + i].d);
     }
     temp[threadIndex] = s;
 

--- a/src/vulkan/matmul-q40-f32.comp
+++ b/src/vulkan/matmul-q40-f32.comp
@@ -1,0 +1,63 @@
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+#define FLOAT_TYPE float
+
+#define QK_40 32
+#define N_THREADS 8
+
+layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
+
+struct BlockQ40 {
+    float16_t d;
+    uint8_t qs[16];
+};
+
+layout(binding = 0) readonly buffer inputBuffer { float inpt[]; };
+layout(binding = 1) readonly buffer weightsBuffer { BlockQ40 weights[]; };
+layout(binding = 2) writeonly buffer outputBuffer { float outp[]; };
+layout(binding = 3) readonly uniform metadataBuffer { uint n; };
+
+shared float temp[N_THREADS];
+
+void main() {
+    const uint nn = n / N_THREADS;
+    const uint nb = n / QK_40;
+    const uint nbn = nb / N_THREADS;
+    const uint threadIndex = uint(gl_LocalInvocationID.x);
+    const uint d = uint(gl_GlobalInvocationID.y);
+
+    const uint iOffset = threadIndex * nn;
+    const uint wOffset = d * nb + threadIndex * nbn;
+
+    float s = 0.0;
+    for (uint i = 0; i < nbn; i++) {
+        float ws = float(weights[wOffset + i].d);
+        uint io = iOffset + i * QK_40;
+        for (uint j = 0; j < QK_40 / 2; j++) {
+            float i0 = inpt[io + j];
+            float i1 = inpt[io + j + QK_40 / 2];
+
+            uint wq = uint(weights[wOffset + i].qs[j]);
+            float w0 = ((wq & 0xF) - 8.0f);
+            float w1 = ((wq >>  4) - 8.0f);
+
+            s += (i0 * w0 + i1 * w1) * ws;
+        }
+    }
+    temp[threadIndex] = s;
+
+    barrier();
+
+    for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
+        if (threadIndex < i)
+            temp[threadIndex] += temp[threadIndex + i];
+        barrier();
+    }
+
+    if (threadIndex == 0) {
+        outp[d] = temp[0];
+    }
+}

--- a/src/vulkan/matmul-q40-f32.comp
+++ b/src/vulkan/matmul-q40-f32.comp
@@ -6,7 +6,7 @@
 #define FLOAT_TYPE float
 
 #define QK_40 32
-#define N_THREADS 8
+#define N_THREADS 16
 
 layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
 
@@ -23,19 +23,21 @@ layout(binding = 3) readonly uniform metadataBuffer { uint n; };
 shared float temp[N_THREADS];
 
 void main() {
-    const uint nn = n / N_THREADS;
-    const uint nb = n / QK_40;
-    const uint nbn = nb / N_THREADS;
     const uint threadIndex = uint(gl_LocalInvocationID.x);
     const uint d = uint(gl_GlobalInvocationID.y);
+    const uint nb = n / QK_40;
 
-    const uint iOffset = threadIndex * nn;
-    const uint wOffset = d * nb + threadIndex * nbn;
+    const uint slice = nb / N_THREADS;
+    const uint rest = nb % N_THREADS;
+    const uint start = threadIndex * slice + (threadIndex < rest ? threadIndex : rest);
+    const uint end = start + slice + (threadIndex < rest ? 1 : 0);
+
+    const uint wOffset = d * nb;
 
     float s = 0.0;
-    for (uint i = 0; i < nbn; i++) {
+    for (uint i = start; i < end; i++) {
         float ws = float(weights[wOffset + i].d);
-        uint io = iOffset + i * QK_40;
+        uint io = i * QK_40;
         for (uint j = 0; j < QK_40 / 2; j++) {
             float i0 = inpt[io + j];
             float i1 = inpt[io + j + QK_40 / 2];

--- a/src/vulkan/matmul-q40-q80.comp
+++ b/src/vulkan/matmul-q40-q80.comp
@@ -1,5 +1,6 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
@@ -42,7 +43,7 @@ void main() {
     float16_t s = float16_t(0.0);
     for (uint i = start; i < end; i++) {
         float16_t s0 = float16_t(0.0);
-        for (uint j = 0; j < QK_40_80 / 2; j++) {
+        [[unroll]] for (uint j = 0; j < QK_40_80 / 2; j++) {
             float16_t i0 = float16_t(inpt[i].qs[j]);
             float16_t i1 = float16_t(inpt[i].qs[j + QK_40_80 / 2]);
 
@@ -58,7 +59,7 @@ void main() {
 
     barrier();
 
-    for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
+    [[unroll]] for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
         if (threadIndex < i)
             temp[threadIndex] += temp[threadIndex + i];
         barrier();

--- a/src/vulkan/matmul-q40-q80.comp
+++ b/src/vulkan/matmul-q40-q80.comp
@@ -6,7 +6,7 @@
 #define FLOAT_TYPE float
 
 #define QK_40_80 32
-#define N_THREADS 8
+#define N_THREADS 16
 
 layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
 
@@ -28,22 +28,25 @@ layout(binding = 3) readonly uniform metadataBuffer { uint n; };
 shared float temp[N_THREADS];
 
 void main() {
-    const uint nb = n / QK_40_80;
-    const uint nbn = nb / N_THREADS;
     const uint threadIndex = uint(gl_LocalInvocationID.x);
     const uint d = uint(gl_GlobalInvocationID.y);
+    const uint nb = n / QK_40_80;
 
-    const uint iOffset = threadIndex * nbn;
-    const uint wOffset = d * nb + iOffset;
+    const uint slice = nb / N_THREADS;
+    const uint rest = nb % N_THREADS;
+    const uint start = threadIndex * slice + (threadIndex < rest ? threadIndex : rest);
+    const uint end = start + slice + (threadIndex < rest ? 1 : 0);
+
+    const uint wOffset = d * nb;
 
     float s = 0.0;
-    for (uint i = 0; i < nbn; i++) {
-        float is = float(inpt[iOffset + i].d);
+    for (uint i = start; i < end; i++) {
+        float is = float(inpt[i].d);
         float ws = float(weights[wOffset + i].d);
 
         for (uint j = 0; j < QK_40_80 / 2; j++) {
-            float i0 = int(inpt[iOffset + i].qs[j]) * is;
-            float i1 = int(inpt[iOffset + i].qs[j + QK_40_80 / 2]) * is;
+            float i0 = int(inpt[i].qs[j]) * is;
+            float i1 = int(inpt[i].qs[j + QK_40_80 / 2]) * is;
 
             uint wq = uint(weights[wOffset + i].qs[j]);
             float w0 = ((wq & 0xF) - 8.0f);

--- a/src/vulkan/matmul-q40-q80.comp
+++ b/src/vulkan/matmul-q40-q80.comp
@@ -6,7 +6,7 @@
 #define FLOAT_TYPE float
 
 #define QK_40_80 32
-#define N_THREADS 16
+#define N_THREADS 32
 
 layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
 
@@ -39,23 +39,22 @@ void main() {
 
     const uint wOffset = d * nb;
 
-    float s = 0.0;
+    float16_t s = float16_t(0.0);
     for (uint i = start; i < end; i++) {
-        float is = float(inpt[i].d);
-        float ws = float(weights[wOffset + i].d);
-
+        float16_t s0 = float16_t(0.0);
         for (uint j = 0; j < QK_40_80 / 2; j++) {
-            float i0 = int(inpt[i].qs[j]) * is;
-            float i1 = int(inpt[i].qs[j + QK_40_80 / 2]) * is;
+            float16_t i0 = float16_t(inpt[i].qs[j]);
+            float16_t i1 = float16_t(inpt[i].qs[j + QK_40_80 / 2]);
 
-            uint wq = uint(weights[wOffset + i].qs[j]);
-            float w0 = ((wq & 0xF) - 8.0f);
-            float w1 = ((wq >>  4) - 8.0f);
+            uint8_t wq = weights[wOffset + i].qs[j];
+            float16_t w0 = float16_t(wq & 0xF) - float16_t(8.0f);
+            float16_t w1 = float16_t(wq >>  4) - float16_t(8.0f);
 
-            s += (i0 * w0 + i1 * w1) * ws;
+            s0 += i0 * w0 + i1 * w1;
         }
+        s += s0 * inpt[i].d * weights[wOffset + i].d;
     }
-    temp[threadIndex] = s;
+    temp[threadIndex] = float(s);
 
     barrier();
 

--- a/src/vulkan/matmul-q40-q80.comp
+++ b/src/vulkan/matmul-q40-q80.comp
@@ -6,7 +6,7 @@
 #define FLOAT_TYPE float
 
 #define QK_40_80 32
-#define N_THREADS 32
+#define N_THREADS 16
 
 layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
 

--- a/src/vulkan/matmul-q40-q80.comp
+++ b/src/vulkan/matmul-q40-q80.comp
@@ -1,0 +1,68 @@
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+#define FLOAT_TYPE float
+
+#define QK_40_80 32
+#define N_THREADS 8
+
+layout(local_size_x = N_THREADS, local_size_y = 1, local_size_z = 1) in;
+
+struct BlockQ40 {
+    float16_t d;
+    uint8_t qs[16];
+};
+
+struct BlockQ80 {
+    float16_t d;
+    int8_t qs[32];
+};
+
+layout(binding = 0) readonly buffer inputBuffer { BlockQ80 inpt[]; };
+layout(binding = 1) readonly buffer weightsBuffer { BlockQ40 weights[]; };
+layout(binding = 2) writeonly buffer outputBuffer { float outp[]; };
+layout(binding = 3) readonly uniform metadataBuffer { uint n; };
+
+shared float temp[N_THREADS];
+
+void main() {
+    const uint nb = n / QK_40_80;
+    const uint nbn = nb / N_THREADS;
+    const uint threadIndex = uint(gl_LocalInvocationID.x);
+    const uint d = uint(gl_GlobalInvocationID.y);
+
+    const uint iOffset = threadIndex * nbn;
+    const uint wOffset = d * nb + iOffset;
+
+    float s = 0.0;
+    for (uint i = 0; i < nbn; i++) {
+        float is = float(inpt[iOffset + i].d);
+        float ws = float(weights[wOffset + i].d);
+
+        for (uint j = 0; j < QK_40_80 / 2; j++) {
+            float i0 = int(inpt[iOffset + i].qs[j]) * is;
+            float i1 = int(inpt[iOffset + i].qs[j + QK_40_80 / 2]) * is;
+
+            uint wq = uint(weights[wOffset + i].qs[j]);
+            float w0 = ((wq & 0xF) - 8.0f);
+            float w1 = ((wq >>  4) - 8.0f);
+
+            s += (i0 * w0 + i1 * w1) * ws;
+        }
+    }
+    temp[threadIndex] = s;
+
+    barrier();
+
+    for (uint i = N_THREADS / 2; i > 0; i >>= 1) {
+        if (threadIndex < i)
+            temp[threadIndex] += temp[threadIndex + i];
+        barrier();
+    }
+
+    if (threadIndex == 0) {
+        outp[d] = temp[0];
+    }
+}


### PR DESCRIPTION
The experimental Vulkan support for the matrix multiplication.

---

To try run Distributed Llama with the Vulkan support you need clone this branch. Also you need to have installed Vulkan dev environment to compile shaders and Distributed Llama with the `-lvulkan` lib.

1. Build Distributed Llama:
```
make dllama DLLAMA_VULKAN=1
```
2. Run Distributed Llama with the `--accelerator=1/1` argument.
```
./dllama inference --accelerator 1/1 \
  --buffer-float-type q80 --prompt "Hello" --steps 128 --nthreads 1 --model models/llama3_8b_q40/dllama_model_llama3_8b_q40.m \
  --tokenizer models/llama3_8b_q40/dllama_tokenizer_llama3_8b_q40.t
```

The value for this argument defines "what percent of the computation should be moved to GPU". `1/1` means 100%. `1/2` means 50% etc.

The current implementation tries to run the inference on CPU and GPU simultaneously. You can still control how many threads should be used by setting the `--nthreads 4` argument. So basically the goal it to find the best values for `--nthreads` argument and the `--accelerator 1/3` argument, to achieve the best speed.