### PR TITLE
Added help/usage to apps and new Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,25 @@ CXXFLAGS = -std=c++11 -Werror -O3 -march=native -mtune=native
 # Conditional settings for Windows
 ifeq ($(OS),Windows_NT)
     LIBS = -lws2_32 # or -lpthreadGC2 if needed
+    DELETECMD = del /f
 else
     LIBS = -lpthread
+    DELETECMD = rm -fv
 endif
 
+.PHONY: all apps clean tests
+
+apps: dllama dllama-api socket-benchmark
+tests: funcs-test quants-test tokenizer-test commands-test llama2-tasks-test
+all: apps tests
+clean:
+	$(DELETECMD) *.o dllama dllama-* socket-benchmark mmap-buffer-* *-test *.exe
 utils: src/utils.cpp
 	$(CXX) $(CXXFLAGS) -c src/utils.cpp -o utils.o
 quants: src/quants.cpp
 	$(CXX) $(CXXFLAGS) -c src/quants.cpp -o quants.o
 funcs: src/funcs.cpp
 	$(CXX) $(CXXFLAGS) -c src/funcs.cpp -o funcs.o
-funcs-test: src/funcs-test.cpp funcs
-	$(CXX) $(CXXFLAGS) src/funcs-test.cpp -o funcs-test funcs.o
 commands: src/commands.cpp
 	$(CXX) $(CXXFLAGS) -c src/commands.cpp -o commands.o
 socket: src/socket.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++11 -Werror -O3 -march=native -mtune=native
+CXXFLAGS = -std=c++11 -Werror -O3 -march=native -mtune=native -Wformat -Werror=format-security
 
 # Conditional settings for Windows
 ifeq ($(OS),Windows_NT)

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -11,12 +11,15 @@
 #include "llama2-tasks.hpp"
 #include "mixtral-tasks.hpp"
 #include "tokenizer.hpp"
+#include <stdexcept>
+#include <string>
 
 class AppArgs {
 public:
     char* mode;
     int nThreads;
     size_t packetAlignment;
+    bool help;
 
     // inference
     char* modelPath;
@@ -49,6 +52,11 @@ public:
 class App {
 public:
     static void run(AppArgs* args, void (*program)(Inference* inference, SocketPool* socketPool, Tokenizer* tokenizer, Sampler* sampler, AppArgs* args, TransformerSpec* spec));
+};
+
+class BadArgumentException : public std::runtime_error {
+public:
+    explicit BadArgumentException(const std::string& message) : std::runtime_error(message) {}
 };
 
 #endif

--- a/src/apps/dllama/dllama.cpp
+++ b/src/apps/dllama/dllama.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #include "../../utils.hpp"
 #include "../../socket.hpp"
@@ -16,7 +17,7 @@
 
 void generate(Inference* inference, SocketPool* socketPool, Tokenizer *tokenizer, Sampler *sampler, AppArgs* args, TransformerSpec* spec) {
     if (args->prompt == NULL)
-        throw std::runtime_error("Prompt is required");
+        throw BadArgumentException("Prompt is required");
 
     // encode the (string) prompt into tokens sequence
     int numPromptTokens = 0;
@@ -220,35 +221,167 @@ void worker(AppArgs* args) {
     delete socketPool;
 }
 
+#ifdef _WIN32
+    #define EXECUTABLE_NAME "dllama.exe"
+#else
+    #define EXECUTABLE_NAME "dllama"
+#endif
+
+bool isValidMode(const char *mode) {
+    if (mode == NULL) {
+        return false;
+    } else {
+        return (strcmp(mode, "generate") == 0) ||
+               (strcmp(mode, "inference") == 0) ||
+               (strcmp(mode, "chat") == 0) ||
+               (strcmp(mode, "worker") == 0);
+    }
+}
+
+std::unordered_map<std::string, std::string> examples = {
+{"generate", ""},
+{"inference", R"(  sudo nice -n -20 ./dllama inference \
+    --prompt "Super briefly describe the 80s - ten words."\
+    --steps 32 --seed 12345 \
+    --model dllama_model_llama3_2_3b_instruct_q40.m \
+    --tokenizer dllama_tokenizer_llama3_2_3b_instruct_q40.t \
+    --buffer-float-type q80 --nthreads 4 --max-seq-len 8192 \
+    --workers 10.0.0.2:9998 10.0.0.3:9998 10.0.0.4:9998
+)"},
+{"chat", R"(  sudo nice -n -20 ./dllama chat \
+    --model dllama_model_llama3_2_3b_instruct_q40.m \
+    --tokenizer dllama_tokenizer_llama3_2_3b_instruct_q40.t \
+    --buffer-float-type q80 --nthreads 4 --max-seq-len 8192 \
+    --workers 10.0.0.2:9998 10.0.0.3:9998 10.0.0.4:9998
+)"},
+{"worker", R"(  sudo nice -n -20 ./dllama worker --port 9998 --nthreads 4
+)"}};
+
+std::string inference_and_generate_usage_string =
+    R"( {inference|generate} {--model <path>} {--tokenizer <path>}
+        {--prompt <p>}
+        [--steps <s>]
+        [--buffer-float-type {f32|f16|q40|q80}]
+        [--weights-float-type {f32|f16|q40|q80}]
+        [--max-seq-len <max>]
+        [--nthreads <n>]
+        [--workers <ip:port> ...]
+        [--packet-alignment <pa>]
+        [--temperature <temp>]
+        [--topp <t>]
+        [--seed <s>]
+)";
+
+std::unordered_map<std::string, std::string> usageText = {
+{"generate", inference_and_generate_usage_string},
+{"inference", inference_and_generate_usage_string},
+{"chat", R"( chat {--model <path>} {--tokenizer <path>}
+        [--buffer-float-type {f32|f16|q40|q80}]
+        [--weights-float-type {f32|f16|q40|q80}]
+        [--max-seq-len <max>]
+        [--nthreads <n>]
+        [--workers <ip:port> ...]
+        [--packet-alignment <pa>]
+        [--temperature <temp>]
+        [--topp <t>]
+        [--seed <s>]
+        [--chat-template {llama2|llama3|zephyr|chatml}]
+)"},
+{"worker", R"( worker [--nthreads <n>] [--port <p>]
+)"}};
+
+#define MULTIPLE_USAGES_PREFIX "       "
+#define SOLO_USAGE_PREFIX "Usage: "
+
+void usage(const char *mode, bool solo=true) {
+    if (!isValidMode(mode)) {
+        fprintf(stderr, "Usage: %s {inference | generate | chat | worker} {ARGS}\n", EXECUTABLE_NAME);
+        usage("inference", false);
+        usage("chat", false);
+        usage("worker", false);
+        fprintf(stderr, "Examples:\n");
+        fprintf(stderr, examples["worker"].c_str());
+        fprintf(stderr, examples["chat"].c_str());
+        fprintf(stderr, examples["inference"].c_str());
+    } else {
+        fprintf(stderr, "%s%s%s",
+                solo ? SOLO_USAGE_PREFIX : MULTIPLE_USAGES_PREFIX,
+                EXECUTABLE_NAME,
+                usageText[mode].c_str());
+        if (solo && (!examples[mode].empty())) {
+            fprintf(stderr, "Example:\n");
+            fprintf(stderr, examples[mode].c_str());
+        }
+    }
+    fflush(stderr);
+}
+
+void usage() {
+    usage(NULL);
+}
+
 int main(int argc, char *argv[]) {
     initQuants();
     initSockets();
 
-    AppArgs args = AppArgs::parse(argc, argv, true);
     bool success = false;
 
-    if (args.mode != NULL) {
-        if (strcmp(args.mode, "inference") == 0) {
-            args.benchmark = true;
-            App::run(&args, generate);
-            success = true;
-        } else if (strcmp(args.mode, "generate") == 0) {
-            args.benchmark = false;
-            App::run(&args, generate);
-            success = true;
-        } else if (strcmp(args.mode, "chat") == 0) {
-            App::run(&args, chat);
-            success = true;
-        } else if (strcmp(args.mode, "worker") == 0) {
-            worker(&args);
-            success = true;
+    try {
+        AppArgs args = AppArgs::parse(argc, argv, true);
+        if (args.help) {
+            if ((args.mode == NULL) ||
+                (strcmp(args.mode, "--usage") == 0) ||
+                (strcmp(args.mode, "--help") == 0) ||
+                (strcmp(args.mode, "-h") == 0)) {
+                usage();
+            } else if (isValidMode(args.mode)) {
+                usage(args.mode);
+            } else {
+                usage();
+                return EXIT_FAILURE;
+            }
+            return EXIT_SUCCESS;
         }
+
+        if (args.mode != NULL) {
+            if (strcmp(args.mode, "inference") == 0) {
+                if (args.prompt == NULL) {
+                    throw BadArgumentException("Prompt is required");
+                }
+                args.benchmark = true;
+                App::run(&args, generate);
+                success = true;
+            } else if (strcmp(args.mode, "generate") == 0) {
+                if (args.prompt == NULL) {
+                    throw BadArgumentException("Prompt is required");
+                }
+                args.benchmark = false;
+                App::run(&args, generate);
+                success = true;
+            } else if (strcmp(args.mode, "chat") == 0) {
+                App::run(&args, chat);
+                success = true;
+            } else if (strcmp(args.mode, "worker") == 0) {
+                worker(&args);
+                success = true;
+            }
+        }
+    } catch (const BadArgumentException& e) {
+        fprintf(stderr, "%s\n\n", e.what());
+        if ((argc > 1) && isValidMode(argv[1])) {
+            usage(argv[1]);
+        } else {
+            usage();
+        }
+        cleanupSockets();
+        return EXIT_FAILURE;
     }
 
     cleanupSockets();
 
     if (success)
         return EXIT_SUCCESS;
-    fprintf(stderr, "Invalid usage\n");
+    fprintf(stderr, "Invalid usage\n\n");
+    usage();
     return EXIT_FAILURE;
 }

--- a/src/apps/dllama/dllama.cpp
+++ b/src/apps/dllama/dllama.cpp
@@ -300,9 +300,9 @@ void usage(const char *mode, bool solo=true) {
         usage("chat", false);
         usage("worker", false);
         fprintf(stderr, "Examples:\n");
-        fprintf(stderr, examples["worker"].c_str());
-        fprintf(stderr, examples["chat"].c_str());
-        fprintf(stderr, examples["inference"].c_str());
+        fprintf(stderr, "%s", examples["worker"].c_str());
+        fprintf(stderr, "%s", examples["chat"].c_str());
+        fprintf(stderr, "%s", examples["inference"].c_str());
     } else {
         fprintf(stderr, "%s%s%s",
                 solo ? SOLO_USAGE_PREFIX : MULTIPLE_USAGES_PREFIX,
@@ -310,7 +310,7 @@ void usage(const char *mode, bool solo=true) {
                 usageText[mode].c_str());
         if (solo && (!examples[mode].empty())) {
             fprintf(stderr, "Example:\n");
-            fprintf(stderr, examples[mode].c_str());
+            fprintf(stderr, "%s", examples[mode].c_str());
         }
     }
     fflush(stderr);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -142,7 +142,7 @@ LlamaRopeCommand::LlamaRopeCommand(RopeSlice *slice) {
 
     size_t cacheBytes = slice->seqLen * slice->sliceDim * sizeof(float);
     cache = (float*)newBuffer(cacheBytes);
-    printf("🕒 ropeCacheSize: %ld kB\n", cacheBytes / 1024);
+    printf("🕒 ropeCacheSize: %zu kB\n", cacheBytes / 1024);
 
     for (pos_t pos = 0; pos < slice->seqLen; pos++) {
         for (unsigned int i = slice->kvDimStart; i < slice->qDimEnd; i += 2) {

--- a/src/funcs.cpp
+++ b/src/funcs.cpp
@@ -5,6 +5,7 @@
 #include "common/pthread.h"
 #include "funcs.hpp"
 #include "utils.hpp"
+#include "app.hpp"
 
 #if defined(__ARM_NEON)
     #include <arm_neon.h>
@@ -461,8 +462,9 @@ void matmul(const FloatType weightsFloatType, const FloatType inputFloatType, fl
         }
     }
 
-    printf("Unsupported float types: %d/%d\n", weightsFloatType, inputFloatType);
-    exit(EXIT_FAILURE);
+    std::string errMsg = "Unsupported float types: '" +
+        std::to_string(weightsFloatType) + "/" + std::to_string(inputFloatType) + "'";
+    throw BadArgumentException(errMsg);
 }
 
 float dotProduct(const float* a, const float* b, const unsigned int size) {

--- a/src/quants.cpp
+++ b/src/quants.cpp
@@ -2,7 +2,9 @@
 #include <cstdint>
 #include <cmath>
 #include <cassert>
+#include <string>
 #include "quants.hpp"
+#include "app.hpp"
 
 #if defined(__ARM_NEON)
     #include <arm_neon.h>
@@ -21,8 +23,8 @@ int getNumbersPerBatch(FloatType type) {
         case FUNK:
             break;
     }
-    fprintf(stderr, "Unsupported float type %d\n", type);
-    exit(EXIT_FAILURE);
+    std::string errMsg = "Unsupported float type '" + std::to_string(type) + "'";
+    throw BadArgumentException(errMsg);
 }
 
 long getBatchBytes(FloatType type, int n, int d) {
@@ -46,8 +48,8 @@ long getBatchBytes(FloatType type, int n, int d) {
         case FUNK:
             break;
     }
-    fprintf(stderr, "Unsupported float type %d\n", type);
-    exit(EXIT_FAILURE);
+    std::string errMsg = "Unsupported float type '" + std::to_string(type) + "'";
+    throw BadArgumentException(errMsg);
 }
 
 float F16ToF32[65536];

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -616,7 +616,7 @@ Transformer Transformer::loadSlice(TransformerSpec* spec, TransformerConfig* con
         }
 
         float kbs = blockBytes / (float)(timeMs() - t0);
-        printf("⏩ Received %ld kB for block %d (%.0f kB/s)\n", blockBytes / 1024, i, kbs);
+        printf("⏩ Received %zu kB for block %d (%.0f kB/s)\n", blockBytes / 1024, i, kbs);
     }
 
     delete[] buffer;


### PR DESCRIPTION
Hi! I've been using distributed-llama for a month or so on the 4x Raspberry Pi 5 cluster that I made, and I saw that dllama and dllama-api didn't have a --usage feature. I'd rather you be focused on meaningful changes to the codebase, so I thought I could help out on this more mundane task, making the tool extremely friendly with respect to usage. I also enhanced the Makefile with a few targets and made the default more meaningful ("make" alone now makes the three apps, instead of just "utils", and I added clean, all, apps, and tests targets).

Here's a pull request. Please let me know if I did anything wrong. :) And keep up the great work!

---

To dllama and dllama-api, I added three arguments that can pull up a usage description: -h, --help, or --usage . Furthermore, for dllama, you can use any of those arguments for just one mode too. So, example uses are:

  ./dllama --usage
  ./dllama --help
  ./dllama -h
  ./dllama chat -h

etc.

Changed some of the places where we were throwing
std::runtime_error exceptions (the ones relating to bad arguments such as poorly formated worker addresses) to now throw a new class, BadArgumentException (which derives from
std::runtime_error). dllama.cpp and dllama-api.cpp catch those and print the error message, then the usage text.

Regular --usage calls at the top exit with EXIT_SUCCESS (0), whereas usages triggered by bad arguments exit with EXIT_FAILURE (1).

Errors now printing usage include invalid float type, invalid chat template type, missing model path argument, missing tokenizer argument, and missing prompt when needed. (Poorly formatted worker addresses display usage too).

Doing a "make" command with no arguments will now make the three apps (dllama, dllama-api, and socket-benchmark), whereas before it was by random chance the utils library. I also added a few new make targets: "apps" (the default 3 apps above), "tests" for the tests, "all: to make the apps and the tests, and a "clean" target that cleans the dir of all compile-generated files (I leave the generated run_ scripts created by launch.py).

A few examples are also output with the usage strings.

Here is some of the output:

--------------------------------
$ ./dllama-api --usage
Usage: dllama-api {--model <path>} {--tokenizer <path>} [--port <p>]
        [--buffer-float-type {f32|f16|q40|q80}]
        [--weights-float-type {f32|f16|q40|q80}]
        [--max-seq-len <max>]
        [--nthreads <n>]
        [--workers <ip:port> ...]
        [--packet-alignment <pa>]
        [--temperature <temp>]
        [--topp <t>]
        [--seed <s>]
Example:
  sudo nice -n -20 ./dllama-api --port 9990 --nthreads 4 \
    --model dllama_model_llama3_2_3b_instruct_q40.m \
    --tokenizer dllama_tokenizer_llama3_2_3b_instruct_q40.t \
    --buffer-float-type q80 --max-seq-len 8192 \
    --workers 10.0.0.2:9998 10.0.0.3:9998 10.0.0.4:9998
$
$
$ ./dllama --usage
Usage: dllama {inference | generate | chat | worker} {ARGS}
       dllama {inference|generate} {--model <path>} {--tokenizer <path>}
        {--prompt <p>}
        [--steps <s>]
        [--buffer-float-type {f32|f16|q40|q80}]
        [--weights-float-type {f32|f16|q40|q80}]
        [--max-seq-len <max>]
        [--nthreads <n>]
        [--workers <ip:port> ...]
        [--packet-alignment <pa>]
        [--temperature <temp>]
        [--topp <t>]
        [--seed <s>]
       dllama chat {--model <path>} {--tokenizer <path>}
        [--buffer-float-type {f32|f16|q40|q80}]
        [--weights-float-type {f32|f16|q40|q80}]
        [--max-seq-len <max>]
        [--nthreads <n>]
        [--workers <ip:port> ...]
        [--packet-alignment <pa>]
        [--temperature <temp>]
        [--topp <t>]
        [--seed <s>]
        [--chat-template {llama2|llama3|zephyr|chatml}]
       dllama worker [--nthreads <n>] [--port <p>]
Examples:
  sudo nice -n -20 ./dllama worker --port 9998 --nthreads 4
  sudo nice -n -20 ./dllama chat \
    --model dllama_model_llama3_2_3b_instruct_q40.m \
    --tokenizer dllama_tokenizer_llama3_2_3b_instruct_q40.t \
    --buffer-float-type q80 --nthreads 4 --max-seq-len 8192 \
    --workers 10.0.0.2:9998 10.0.0.3:9998 10.0.0.4:9998
  sudo nice -n -20 ./dllama inference \
    --prompt "Super briefly describe the 80s - ten words."\
    --steps 32 --seed 12345 \
    --model dllama_model_llama3_2_3b_instruct_q40.m \
    --tokenizer dllama_tokenizer_llama3_2_3b_instruct_q40.t \
    --buffer-float-type q80 --nthreads 4 --max-seq-len 8192 \
    --workers 10.0.0.2:9998 10.0.0.3:9998 10.0.0.4:9998
$
$ ./dllama chat -h
Usage: dllama chat {--model <path>} {--tokenizer <path>}
        [--buffer-float-type {f32|f16|q40|q80}]
        [--weights-float-type {f32|f16|q40|q80}]
        [--max-seq-len <max>]
        [--nthreads <n>]
        [--workers <ip:port> ...]
        [--packet-alignment <pa>]
        [--temperature <temp>]
        [--topp <t>]
        [--seed <s>]
        [--chat-template {llama2|llama3|zephyr|chatml}]
Example:
  sudo nice -n -20 ./dllama chat \
    --model dllama_model_llama3_2_3b_instruct_q40.m \
    --tokenizer dllama_tokenizer_llama3_2_3b_instruct_q40.t \
    --buffer-float-type q80 --nthreads 4 --max-seq-len 8192 \
    --workers 10.0.0.2:9998 10.0.0.3:9998 10.0.0.4:9998
$

--------------------------------

We now check whether the prompt argument is present for the generate and inference targets before loading the model, so someone getting the usage wrong will know immediately.