### PR TITLE
fix: fixed inference getting stuck

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -234,8 +234,10 @@ void runInferenceApp(AppCliArgs *args, void (*handler)(AppInferenceContext *cont
 
     RootLlmInference inference(&net, &cpu, &execution, &executor, network);
 
-    if (network != nullptr)
+    if (network != nullptr) {
         network->resetStats();
+        network->setTurbo(true);
+    }
 
     AppInferenceContext context;
     context.args = args;

--- a/src/nn/nn-network.cpp
+++ b/src/nn/nn-network.cpp
@@ -525,8 +525,7 @@ static void syncNodeSlices(bool onlyFromWorkerToRoot, NnNetwork *network, NnSize
     if (nSocketsPerThread == 0) return;
     NnSize sliceBytes = nBytes / nNodes;
 
-    std::unique_ptr<NnSocketIo> iosPtr(new NnSocketIo[nSocketsPerThread]);
-    NnSocketIo *ios = iosPtr.get();
+    std::vector<NnSocketIo> ios(nSocketsPerThread);
 
     if (!onlyFromWorkerToRoot || isWorker) {
         NnByte *mySliceData = &buffer[sliceBytes * nodeIndex];
@@ -537,7 +536,7 @@ static void syncNodeSlices(bool onlyFromWorkerToRoot, NnNetwork *network, NnSize
             ios[i].data = mySliceData;
             ios[i].size = sliceBytes;
         }
-        network->writeMany(nSocketsPerThread, ios);
+        network->writeMany(nSocketsPerThread, &ios[0]);
     }
 
     if (!onlyFromWorkerToRoot || !isWorker) {
@@ -549,7 +548,7 @@ static void syncNodeSlices(bool onlyFromWorkerToRoot, NnNetwork *network, NnSize
             ios[i].data = sliceData;
             ios[i].size = sliceBytes;
         }
-        network->readMany(nSocketsPerThread, ios);
+        network->readMany(nSocketsPerThread, &ios[0]);
     }
 }
 


### PR DESCRIPTION
This PR resolves an issue where inference would get stuck during long runs. I have tested it in a single run up to pos=5000 without any issues, and it should work for higher positions as well.