### PR TITLE
dllama-api: /v1/models: return basename of the model

### DIFF
--- a/src/dllama-api.cpp
+++ b/src/dllama-api.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <algorithm>
 #include <vector>
+#include <string>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -492,11 +493,16 @@ void handleCompletionsRequest(HttpRequest& request, ApiServer *api) {
     api->complete(request);
 }
 
-void handleModelsRequest(HttpRequest& request) {
+void handleModelsRequest(HttpRequest& request, const char* modelPath) {
+    std::string path(modelPath);
+
+    size_t pos = path.find_last_of("/\\");
+    std::string modelName = (pos == std::string::npos) ? path : path.substr(pos+1);
+
     request.writeJson(
         "{ \"object\": \"list\","
         "\"data\": ["
-        "{ \"id\": \"dl\", \"object\": \"model\", \"created\": 0, \"owned_by\": \"user\" }"
+        "{ \"id\": \"" + modelName + "\", \"object\": \"model\", \"created\": 0, \"owned_by\": \"user\" }"
         "] }");
 }
 
@@ -519,7 +525,7 @@ static void server(AppInferenceContext *context) {
         {
             "/v1/models",
             HttpMethod::METHOD_GET,
-            std::bind(&handleModelsRequest, std::placeholders::_1)
+            std::bind(&handleModelsRequest, std::placeholders::_1, context->args->modelPath)
         }
     };
 


### PR DESCRIPTION
Change the `/v1/models` api endpoint to return the basename of the model path instead of the hardcoded value `"dl"`.

Successfully tested with [Open WebUI](https://docs.openwebui.com/). Makes identifying the current model in use a little easier.

This works, but my C++ knowledge is a little limited. So this can be taken as a more detailed feature request instead :)

![image](https://github.com/user-attachments/assets/f38c7119-030f-4a92-bded-7fed8405dccf)
