### PR TITLE
fix: converter hf now handles byte characters. Closes #188

### DIFF
--- a/converter/convert-tokenizer-hf.py
+++ b/converter/convert-tokenizer-hf.py
@@ -72,7 +72,12 @@ class TokensResolver:
             t = processor.id_to_piece(i)
             s = processor.get_score(i)
             t = t.replace('▁', ' ') # sentencepiece uses this character as whitespace
-            b = t.encode('utf-8')
+            # Check for byte characters
+            if len(t) == 6 and t.startswith('<0x') and t.endswith('>'):
+                # For example, "<0x0A>"" is a newline character
+                b = bytearray.fromhex(t[3:-1])
+            else:
+                b = t.encode('utf-8')
             self.tokens.append(b)
             self.scores.append(s)
 


### PR DESCRIPTION
The converter-tokenizer-hf is now aware of byte characters (such as `"<0x0A>"` and parses them correctly as the actual character (such as a newline `"\n"`.

This is useful for mistral, tinyllama, and others using the same tokenizing method. 

See https://github.com/ggml-org/llama.cpp/issues/4622 for more context.

Fix #188.