### PR TITLE
fix: vulkan memory type.

### DIFF
--- a/src/nn/nn-vulkan.cpp
+++ b/src/nn/nn-vulkan.cpp
@@ -130,12 +130,28 @@ NnVulkanBuffer::NnVulkanBuffer(NnVulkanContext *context, const vk::DeviceSize bu
 
     uint32_t memoryTypeIndex = MEMORY_TYPE_INDEX_NOT_FOUND;
     if (fastAccess) {
-        memoryTypeIndex = findMemoryTypeIndex(&context->physicalDevice, vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eDeviceLocal);
+        memoryTypeIndex = findMemoryTypeIndex(
+            &context->physicalDevice,
+            vk::MemoryPropertyFlagBits::eHostVisible |
+            vk::MemoryPropertyFlagBits::eHostCoherent |
+            vk::MemoryPropertyFlagBits::eHostCached |
+            vk::MemoryPropertyFlagBits::eDeviceLocal
+        );
+        if (memoryTypeIndex == MEMORY_TYPE_INDEX_NOT_FOUND)
+            memoryTypeIndex = findMemoryTypeIndex(
+                &context->physicalDevice,
+                vk::MemoryPropertyFlagBits::eHostVisible |
+                vk::MemoryPropertyFlagBits::eHostCoherent |
+                vk::MemoryPropertyFlagBits::eDeviceLocal
+            );
         if (memoryTypeIndex != MEMORY_TYPE_INDEX_NOT_FOUND)
             isHostVisible = true;
     }
     if (!isHostVisible) {
-        memoryTypeIndex = findMemoryTypeIndex(&context->physicalDevice, vk::MemoryPropertyFlagBits::eDeviceLocal);
+        memoryTypeIndex = findMemoryTypeIndex(
+            &context->physicalDevice,
+            vk::MemoryPropertyFlagBits::eDeviceLocal
+        );
         if (memoryTypeIndex == MEMORY_TYPE_INDEX_NOT_FOUND)
             throw std::runtime_error("Cannot find host visible memory type");
     }

--- a/src/nn/nn-vulkan.cpp
+++ b/src/nn/nn-vulkan.cpp
@@ -134,15 +134,13 @@ NnVulkanBuffer::NnVulkanBuffer(NnVulkanContext *context, const vk::DeviceSize bu
             &context->physicalDevice,
             vk::MemoryPropertyFlagBits::eHostVisible |
             vk::MemoryPropertyFlagBits::eHostCoherent |
-            vk::MemoryPropertyFlagBits::eHostCached |
-            vk::MemoryPropertyFlagBits::eDeviceLocal
+            vk::MemoryPropertyFlagBits::eHostCached
         );
         if (memoryTypeIndex == MEMORY_TYPE_INDEX_NOT_FOUND)
             memoryTypeIndex = findMemoryTypeIndex(
                 &context->physicalDevice,
                 vk::MemoryPropertyFlagBits::eHostVisible |
-                vk::MemoryPropertyFlagBits::eHostCoherent |
-                vk::MemoryPropertyFlagBits::eDeviceLocal
+                vk::MemoryPropertyFlagBits::eHostCoherent
             );
         if (memoryTypeIndex != MEMORY_TYPE_INDEX_NOT_FOUND)
             isHostVisible = true;


### PR DESCRIPTION
This version fixes the selection of memory type in Vulkan, significantly improving inference speed on NVIDIA GPUs.

With this, it's now possible to run Distributed Llama on two GPUs within the same machine, for example. Check [this test](https://github.com/b4rtaz/distributed-llama/discussions/194).