### PR TITLE
feat: support more than 2 eos tokens

### DIFF
--- a/converter/convert-tokenizer-hf.py
+++ b/converter/convert-tokenizer-hf.py
@@ -56,7 +56,7 @@ class TokensResolver:
             if (self.eosIds is None):
                 self.eosIds = config['eos_token_id']
                 if isinstance(self.eosIds, list):
-                    self.eosIds = self.eosIds[:2] # TODO: add support more than 2 eos ids
+                    self.eosIds = self.eosIds
                 else:
                     self.eosIds = [self.eosIds]
 
@@ -124,10 +124,12 @@ if __name__ == '__main__':
             chatExtraStop = input.encode('utf-8')
 
     outputFileName = f'dllama_tokenizer_{name}.t'
+    write_params = [
+        ('bos_id', resolver.bosId),
+        ('eos_id', resolver.eosIds[0])
+    ]
+    for eos_id in resolver.eosIds[1:]:
+        write_params += [('chat_eos_id', eos_id)]
     with open(outputFileName, 'wb') as outputFile:
-        writer.writeTokenizer(outputFile, {
-            'bos_id': resolver.bosId,
-            'eos_id': resolver.eosIds[0],
-            'chat_eos_id': resolver.eosIds[1 if len(resolver.eosIds) > 1 else 0],
-        }, resolver.tokens, resolver.scores, chatTemplate, chatExtraStop)
+        writer.writeTokenizer(outputFile, write_params, resolver.tokens, resolver.scores, chatTemplate, chatExtraStop)
     print(f'✅ Created {outputFileName}')

--- a/converter/convert-tokenizer-llama2.py
+++ b/converter/convert-tokenizer-llama2.py
@@ -33,10 +33,10 @@ if __name__ == '__main__':
 
     outputFileName = 'dllama_tokenizer_llama2.t'
     with open(outputFileName, 'wb') as outputFile:
-        writer.writeTokenizer(outputFile, {
-            'bos_id': processor.bos_id(),
-            'eos_id': processor.eos_id(),
-            'chat_eos_id': processor.eos_id(),
-        }, tokens, scores, chatTemplate.encode('utf-8'), None)
+        writer.writeTokenizer(outputFile, [
+            ('bos_id', processor.bos_id()),
+            ('eos_id', processor.eos_id()),
+            ('chat_eos_id', processor.eos_id())
+        ], tokens, scores, chatTemplate.encode('utf-8'), None)
 
     print(f'✅ Created {outputFileName}')

--- a/converter/convert-tokenizer-llama3.py
+++ b/converter/convert-tokenizer-llama3.py
@@ -67,10 +67,10 @@ if __name__ == '__main__':
                 scores.append(score)
                 specialTokenIndex += 1
 
-            writer.writeTokenizer(outputFile, {
-                'bos_id': bosId,
-                'eos_id': eosId,
-                'chat_eos_id': chatEosId,
-            }, tokens, scores, chatTemplate.encode('utf-8'), None)
+            writer.writeTokenizer(outputFile, [
+                ('bos_id', bosId),
+                ('eos_id', eosId),
+                ('chat_eos_id', chatEosId)
+            ], tokens, scores, chatTemplate.encode('utf-8'), None)
 
     print(f'✅ Created {outputFileName}')

--- a/converter/convert-tokenizer-llama3.py
+++ b/converter/convert-tokenizer-llama3.py
@@ -28,6 +28,7 @@ specialTokens = [
 ]
 bosId = 128000
 eosId = 128001
+chatEomId = 128008
 chatEosId = 128009
 chatTemplate = "{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' %}{% if loop.index0 == 0 %}{% set content = bos_token + content %}{% endif %}{{ content }}{% endfor %}{% if add_generation_prompt %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}{% endif %}"
 
@@ -70,6 +71,7 @@ if __name__ == '__main__':
             writer.writeTokenizer(outputFile, [
                 ('bos_id', bosId),
                 ('eos_id', eosId),
+                ('chat_eos_id', chatEomId),
                 ('chat_eos_id', chatEosId)
             ], tokens, scores, chatTemplate.encode('utf-8'), None)
 


### PR DESCRIPTION
In some models, such as [Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct), a third token `<|eom_id|>` behaves as EOS. Failing to identify that may cause the assistant to output content infinitely, especially if converted from hf.

This patch alters the conversion script so that models with more than 2 EOS tokens will create multiple tokenizer chat_eos_id headers. The C++ side of impl already supports this.

This patch did so by altering tokenizer header params to a list of binary tuples -- instead of a dict, matching how the C++ side processes the .t file.

As the Llama-3.1-8B-Instruct is an official llama3 model, I added `<|eom_id|>` to convert_tokenizer_llama3 too. However, as I'm not totally familiar with llama3, this could use more reasoning.