### PR TITLE
fix: make api server ignore SIGPIPE if needed

### DIFF
--- a/src/dllama-api.cpp
+++ b/src/dllama-api.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <csignal>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -569,6 +570,10 @@ void usage() {
 }
 
 int main(int argc, char *argv[]) {
+#ifdef SIGPIPE
+    std::signal(SIGPIPE, SIG_IGN);
+#endif
+
     initQuants();
     initSockets();
 


### PR DESCRIPTION
Unix-like systems generate SIGPIPE on an aborted socket connection. Not ignoring such a signal will cause the API server to crash.