### PR TITLE
fix: reset EOS detector across requests

### DIFF
--- a/src/dllama-api.cpp
+++ b/src/dllama-api.cpp
@@ -405,6 +405,7 @@ public:
 
         inference->setBatchSize(1);
         tokenizer->resetDecoder();
+        eosDetector->reset();
 
         for (; pos < maxPredPos;) {
             inference->setPosition(pos);


### PR DESCRIPTION
The EOS detector caches data inside it. Not resetting it may result in the remains of the last response appearing at the start of the next response.