### PR TITLE
fix: Tokenizer utf-8 handling

### DIFF
--- a/src/tokenizer-test.cpp
+++ b/src/tokenizer-test.cpp
@@ -68,6 +68,22 @@ void dev_testEncode(Tokenizer *tokenizer) {
     }
 }
 
+void dev_testDecoderEmojiStreamRecover(Tokenizer *tokenizer) {
+    char *x0 = tokenizer->decode(128000);
+    assert(x0 == nullptr);
+
+    char *x1 = tokenizer->decode(76460);
+    assert(x1 == nullptr);
+
+    char *x2 = tokenizer->decode(76460);
+    assert(x2 == nullptr);
+
+    char *x3 = tokenizer->decode(225);
+    assert(strcmp(x3, "�😃") == 0);
+
+    printOk("testDecoderEmojiStreamRecover");
+}
+
 void dev_testDecoderEmoji(Tokenizer *tokenizer) {
     char *x0 = tokenizer->decode(128000);
     assert(x0 == nullptr);
@@ -76,27 +92,30 @@ void dev_testDecoderEmoji(Tokenizer *tokenizer) {
     assert(x1 == nullptr);
 
     char *x2 = tokenizer->decode(225);
-    assert(x2 == nullptr);
+    assert(strcmp(x2, "😃") == 0);
 
     char *x3 = tokenizer->decode(0);
-    assert(strstr(x3, "😃!") != NULL);
+    assert(strcmp(x3, "!") == 0);
 
     char *x4 = tokenizer->decode(56);
-    assert(strstr(x3, "Y") != NULL);
+    assert(strcmp(x4, "Y") == 0);
 
     printOk("testDecoderEmoji");
 }
 
 void dev_testDecoderEmojiWithEos(Tokenizer *tokenizer) {
     char *x0 = tokenizer->decode(128000);
-    char *x1 = tokenizer->decode(76460);
-    char *x2 = tokenizer->decode(225);
-    char *x3 = tokenizer->decode(128001);
-
     assert(x0 == nullptr);
+
+    char *x1 = tokenizer->decode(76460);
     assert(x1 == nullptr);
-    assert(x2 == nullptr);
-    assert(strstr(x3, "😃") != NULL); // piece should not contain <|end_of_text|>
+
+    char *x2 = tokenizer->decode(225);
+    assert(strcmp(x2, "😃") == 0);
+
+    char *x3 = tokenizer->decode(128001);
+    assert(x3 == nullptr); // piece should not contain <|end_of_text|>
+
     printOk("decoderEmojiWithEos");
 }
 
@@ -289,6 +308,7 @@ int main() {
     dev_testEncode(&tokenizer);
     dev_testDecoderEmoji(&tokenizer);
     dev_testDecoderEmojiWithEos(&tokenizer);
+    dev_testDecoderEmojiStreamRecover(&tokenizer);
 #endif
 
     testChatTemplateDetection();

--- a/src/tokenizer.hpp
+++ b/src/tokenizer.hpp
@@ -42,6 +42,7 @@ private:
     TokenIndex *specialVocab;
     size_t strBufferSize;
     char *strBuffer;
+    char *utf8Buffer;
     size_t strBufferPos;
 
 
@@ -60,6 +61,9 @@ public:
     bool isEos(int token);
     char *decode(int token);
     void resetDecoder();
+
+private:
+    char *detokUtf8();
 };
 
 typedef struct {


### PR DESCRIPTION
This patch fixes up the Tokenizer to do UTF-8 sanitization properly.

The original impl does a piggyback for multi-byte sequences, returning the sequence only after a following token ending in the Latin-1 character set(0~0x7f, single byte)  is met. This might work with languages that consist mainly of Latin-1 letters, but does not work with, for example, CJK languages, which could easily build up a wall of multi-byte sequences.

Furthermore, the LLM model is not guaranteed to output a valid UTF-8 sequence. It outputs an array of tok_id, which makes it possible to match an invalid UTF-8 sequence. So, it's also necessary to perform UTF-8 stream recovery.

This patch achieves the above requirements by adding a function `detokUtf8`. This function scans for a valid UTF-8 sequence at the beginning of `strBuffer`, then puts the valid sequence in `utf8Buffer` and returns it. If trailing bytes exist, it will perform buffer sliding by `memmove`.

If an invalid sequence is encountered, it will emit `U+0xfffd`, print a warning, and perform stream recovery.

Also added a few more tests. They may help a lot in understanding what this code does.

