### PR TITLE
feat: reduce gpu sync size.

### DIFF
--- a/src/nn/nn-vulkan.hpp
+++ b/src/nn/nn-vulkan.hpp
@@ -6,8 +6,6 @@
 #include "nn-executor.hpp"
 #include "nn-cpu-ops.hpp"
 
-#define DEBUG_VULKAN_TRACE false
-
 typedef struct {
     vk::Instance instance;
     vk::PhysicalDevice physicalDevice;
@@ -15,6 +13,7 @@ typedef struct {
     uint32_t queueFamilyIndex;
     vk::CommandPool commandPool;
     vk::Queue queue;
+    NnSize nonCoherentAtomSize;
 } NnVulkanContext;
 
 enum NnStagingVulkanCopyDirection {
@@ -47,13 +46,16 @@ private:
     void *hostPointer;
 public:
     const char *name;
-    vk::DeviceSize bufferSize;
+    NnSize bufferSize;
     vk::Buffer deviceBuffer;
     vk::BufferUsageFlags usageFlags;
-    NnVulkanBuffer(NnVulkanContext *context, const char *name, const vk::DeviceSize bufferSize, vk::BufferUsageFlags usageFlags, bool fastAccess);
+    NnVulkanBuffer(NnVulkanContext *context, const char *name, const NnSize bufferSize, vk::BufferUsageFlags usageFlags, bool fastAccess);
     ~NnVulkanBuffer();
     void write(const NnByte *data);
+    void write(const NnByte *data, const NnSize size);
     void read(NnByte *data);
+    void read(NnByte *data, const NnSize size);
+    NnSize calcSliceSize(const NnSize nominator, const NnSize denominator);
 };
 
 typedef struct {


### PR DESCRIPTION
This PR reduces the number of bytes required for synchronization between the CPU and GPU in prediction mode.

Tested on NVIDIA GeForce RTX 3060 12GB (with `--steps 128`):

| Model | Tokens/s (previous version) | Tokens/s (this PR) |
| --- | --- | --- |
| `lama3_1_8b_instruct_q40` | 13.68 (73.07 ms/tok) | 14.83 (67.42 ms/tok) |
| `qwen3_0.6b_q40` | 44.41 (22.52 ms/tok) | 61.98 (16.13 ms/tok) |