### PR TITLE
fix: vulkan matmul q80 q40 f32 precision.

### DIFF
--- a/src/nn/vulkan/matmul-forward-q80-q40-f32.comp
+++ b/src/nn/vulkan/matmul-forward-q80-q40-f32.comp
@@ -35,7 +35,7 @@ layout(binding = 1) writeonly buffer outputBuffer { float y[]; };
 layout(binding = 2) readonly uniform batchInfosBuffer { BatchInfo infos[N_BATCHES]; };
 layout(binding = 3) readonly buffer weightBuffer { BlockQ40 weight[]; };
 
-shared float16_t sums[MAX_THREADS * TILE_SIZE_D];
+shared float sums[MAX_THREADS * TILE_SIZE_D];
 
 void main() {
     const uint nThreads = gl_WorkGroupSize.x;
@@ -56,18 +56,18 @@ void main() {
     const uint xStart = (threadIndex * xSlice + min(threadIndex, xRest)) * TILE_SIZE_X;
     const uint xEnd = xStart + (xSlice + (threadIndex < xRest ? 1 : 0)) * TILE_SIZE_X;
 
-    f16vec4 xTemp[Q80_Q40_BLOCK_SIZE / 4];
+    vec4 xTemp[Q80_Q40_BLOCK_SIZE / 4];
 
     for (uint dt = 0; dt < TILE_SIZE_D; dt++) {
-        sums[threadIndex * TILE_SIZE_D + dt] = float16_t(0.0f);
+        sums[threadIndex * TILE_SIZE_D + dt] = 0.0f;
     }
 
     for (uint i = xStart; i < xEnd; i += TILE_SIZE_X) {
         [[unroll]] for (uint it = 0; it < TILE_SIZE_X; it++) {
             const uint xi = inputOffset + i + it;
-            const float16_t xScale = x[xi].d;
+            const float xScale = float(x[xi].d);
             [[unroll]] for (uint j = 0; j < Q80_Q40_BLOCK_SIZE / 4; j++) {
-                xTemp[j] = f16vec4(
+                xTemp[j] = vec4(
                     x[xi].qs[j * 2],
                     x[xi].qs[j * 2 + Q80_Q40_BLOCK_SIZE / 2],
                     x[xi].qs[j * 2 + 1],
@@ -79,17 +79,16 @@ void main() {
                 const uint wi = (d + dt) * inputSizeX + (i + it);
                 const BlockQ40 wBlock = weight[wi];
 
-                float16_t s = float16_t(0.0f);
+                float s = 0.0f;
                 [[unroll]] for (uint j = 0; j < Q80_Q40_BLOCK_SIZE / 4; j++) {
                     uint w0 = wBlock.qs[j * 2];
                     uint w1 = wBlock.qs[j * 2 + 1];
-                    ivec4 w = ivec4(
-                        w0 & 0xFu,
-                        w0 >> 4,
-                        w1 & 0xFu,
-                        w1 >> 4
-                    ) - ivec4(8);
-                    s += dot(xTemp[j], f16vec4(w));
+                    s += dot(xTemp[j], vec4(
+                        int(w0 & 0xFu) - 8,
+                        int(w0 >> 4) - 8,
+                        int(w1 & 0xFu) - 8,
+                        int(w1 >> 4) - 8
+                    ));
                 }
                 sums[threadIndex * TILE_SIZE_D + dt] += s * xScale * wBlock.d;
             }
@@ -107,6 +106,6 @@ void main() {
         barrier();
     }
     for (uint dt = threadIndex; dt < TILE_SIZE_D; dt += nThreads) {
-        y[outputOffset + d + dt] = float(sums[dt]);
+        y[outputOffset + d + dt] = sums[dt];
     }
 }


### PR DESCRIPTION
This PR fixes a precision issue in multiplication for Qwen models on NVIDIA GPUs.

### Performance tests

Tested on NVIDIA GeForce RTX 3060 12GB.

```
🌋 Device: NVIDIA GeForce RTX 3060                                                                                                                
🌋 DeviceApiVersion: 1.4.303                                                                                                                      
🌋 MaxComputeSharedMemory: 48 kB                                                                                                                  
🌋 NonCoherentAtomSize: 64 bytes                                                                                                                  
🌋 Heap[0]: 12288 MB                                                                                                                              
🌋 Heap[2]: 246 MB
```

### Prediction (--steps 128)

| Model | Tokens/s (version 0.15.0) | Tokens/s (version 0.15.2) | Tokens/s (This PR) |
| --- | --- | --- | --- |
| `qwen3_8b_q40` | 12.9 | 13.65 | 16.86 |