### PR TITLE
chore: use cpp highlight for `.comp`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.comp linguist-language=C++


### PR DESCRIPTION
Using `.gitattributes` to treat `.comp` files as `.cpp`, we get nice syntax highlighting on GitHub web view. This PR adds the necessary attribute for that. Note that this will also count the `.comp` files as `.cpp` files for the language distribution stat.

EDIT: See example [here](https://github.com/erhant/distributed-llama/blob/main/src/nn/vulkan/matmul-forward-q80-q40-f32.comp)