### PR TITLE
fix error for pip install

### DIFF
--- a/converter/requirements.txt
+++ b/converter/requirements.txt
@@ -3,3 +3,4 @@ numpy==1.23.5
 torch==2.0.1+cpu --index-url https://download.pytorch.org/whl/cpu
 safetensors==0.4.2
 sentencepiece==0.1.99
+transformers==4.57.6


### PR DESCRIPTION

```
ERROR: Could not find a version that satisfies the requirement python>=3.9 (from -r requirements.txt (line 1)) (from versions: none)
ERROR: No matching distribution found for python>=3.9 (from -r requirements.txt (line 1))
```

```
ERROR: Could not find a version that satisfies the requirement pytorch==2.0.1 (from versions: 0.1.2, 1.0.2)
ERROR: No matching distribution found for pytorch==2.0.1
```