### PR TITLE
fix: pad tokenizer vocab to match model vocab_size

### DIFF
--- a/converter/convert-tokenizer-hf.py
+++ b/converter/convert-tokenizer-hf.py
@@ -46,10 +46,21 @@ class TokensResolver:
             self.tokens.append(bytes(tokenBytes))
             self.scores.append(-float(i))
 
+        # Pad tokenizer vocab to match model vocab_size if needed
+        configPath = os.path.join(self.dirPath, 'config.json')
+        if os.path.exists(configPath):
+            config = openJson(configPath)
+            targetVocabSize = config.get('vocab_size', vocabLen)
+            if targetVocabSize > vocabLen:
+                print(f'⚠️ Padding tokenizer vocab from {vocabLen} to {targetVocabSize}')
+                for i in range(vocabLen, targetVocabSize):
+                    self.tokens.append(f'<|reserved_{i}|>'.encode('utf-8'))
+                    self.scores.append(-float(i))
+
         self.bosId = tokenizer.bos_token_id
         if (tokenizer.eos_token_id):
             self.eosIds = [tokenizer.eos_token_id]
-        if (self.bosId is None or self.eosId is None):
+        if (self.bosId is None or self.eosIds is None):
             config = openJson(os.path.join(self.dirPath, 'config.json'))
             if (self.bosId is None):
                 self.bosId = config['bos_token_id']


### PR DESCRIPTION
Some models like Qwen3-Coder-30B-A3B have reserved tokens that are not in the tokenizer.json but are defined in config.json vocab_size. This causes a vocab size mismatch error at runtime.

This fix pads the tokenizer with placeholder tokens to match the model's expected vocab_size.

Tested with:
- Qwen3-Coder-30B-A3B-Instruct (vocab 151669 -> 151936)